### PR TITLE
Removed test folder from sonarcloud exclusion

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
   solutionType: angularDotNetCore # angularDotNetCore, dotNetCore
   apiDirectory: 'AdminWebsite/AdminWebsite'
   sonarCloudPrepareExtraProperties: |  
-    sonar.exclusions=**/node_modules/**,**/*.spec.ts,*.spec.ts,**/ClientApp/src/*,**/ClientApp/coverage/**/*, **/ClientApp/src/app/testing/**
+    sonar.exclusions=**/node_modules/**,**/*.spec.ts,*.spec.ts,**/ClientApp/src/*,**/ClientApp/coverage/**/*
     sonar.typescript.lcov.reportPaths=$(System.DefaultWorkingDirectory)/AdminWebsite/AdminWebsite/ClientApp/coverage/lcov.info
     sonar.typescript.exclusions=**/node_modules/**,**/typings.d.ts,**/main.ts,**/environments/environment*.ts,**/*routing.module.ts,**/api-client.ts
     sonar.cs.opencover.reportsPaths=$(Common.TestResultsDirectory)\Coverage\coverage.opencover.xml


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
In attempt to exclude some test classes from test coverage exclusion, the folder was accidentally put into general sonarcloud exclusion meaning we wouldn't get code quality analysis on it either. I've reverted this now.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
