### PR TITLE
Updated account we use for accessing devops templates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ resources:
   - repository: azureDevOpsTemplates
     type: github
     name: hmcts/azure-devops-templates
-    endpoint: 'GitHub connection 1'
+    endpoint: 'GitHubDevOps'
 
 trigger:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,9 +31,6 @@ resources:
     name: hmcts/azure-devops-templates
     endpoint: 'GitHubDevOps'
 
-trigger:
-- master
-
 jobs:
 - template: jobs/angularDotNetCore.yml@azureDevOpsTemplates # Template reference
   parameters:


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
Fixed issue with using wrong credentials on build:
![image](https://user-images.githubusercontent.com/8461739/59620062-d67e6000-9123-11e9-847c-22aee1d042a0.png)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
