### PR TITLE
Refactor component references

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.html
@@ -81,7 +81,7 @@
         </select>
       </div>
       <div *ngIf="showDetails">
-        <app-search-email (findParticipant)="getParticipant($event)" (participantsNotFound)="notFoundParticipant()"
+        <app-search-email [disabled]="emailDisabled" (findParticipant)="getParticipant($event)" (participantsNotFound)="notFoundParticipant()"
           (emailChanged)="emailChanged()">
         </app-search-email>
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.spec.ts
@@ -216,10 +216,7 @@ describe('AddParticipantComponent', () => {
       routerSpy,
       bookingServiceSpy
     );
-    component.searchEmail = new SearchEmailComponent(
-      searchService,
-      jasmine.createSpyObj<ElementRef>(['nativeElement'])
-    );
+    component.searchEmail = new SearchEmailComponent(searchService);
     component.participantsListComponent = new ParticipantsListComponent(
       bookingServiceSpy, routerSpy
     );

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.ts
@@ -27,6 +27,7 @@ export class AddParticipantComponent extends BookingBaseComponent implements OnI
   canNavigate = true;
   constants = Constants;
 
+  emailDisabled = false;
   participantDetails: ParticipantModel;
   notFound: boolean;
   hearing: HearingModel;
@@ -159,8 +160,8 @@ export class AddParticipantComponent extends BookingBaseComponent implements OnI
   private setParticipantEmail() {
     this.searchEmail.email = this.participantDetails.email;
     this.searchEmail.isValidEmail = true;
-    this.searchEmail.setEmailDisabled((this.participantDetails.id && this.participantDetails.id.length > 0)
-      || this.participantDetails.is_exist_person);
+    const participantHasId = this.participantDetails.id && this.participantDetails.id.length > 0;
+    this.emailDisabled = participantHasId || this.participantDetails.is_exist_person;
   }
 
   initializeForm() {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.ts
@@ -275,6 +275,7 @@ export class AddParticipantComponent extends BookingBaseComponent implements OnI
 
     if (participantDetails.is_exist_person) {
       this.disableLastFirstNames();
+      this.emailDisabled = true;
       this.existingPersonEmails.push(participantDetails.email);
     }
     this.existingParticipant = participantDetails.id && participantDetails.id.length > 0;
@@ -748,6 +749,7 @@ export class AddParticipantComponent extends BookingBaseComponent implements OnI
     this.form.get('role').disable();
   }
   enableFields() {
+    this.emailDisabled = false;
     this.form.get('lastName').enable();
     this.form.get('firstName').enable();
     this.form.get('party').enable();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.html
@@ -1,4 +1,4 @@
-<div>
+<div (blur)="blur()">
   <div class="govuk-form-group" [ngClass]="{'govuk-form-group--error':!isValidEmail}">
     <div *ngIf="!isValidEmail">
       <span class="govuk-error-message">
@@ -8,7 +8,7 @@
     <label class="govuk-label" for="participantEmail">
       Email
     </label>
-    <input #emailInput (blur)="blur()" [attr.disabled]="disabled ? true : null" id="participantEmail" name="participantEmail" [(ngModel)]="email" (blur)="blurEmail()" class="govuk-input govuk-input--width-20"
+    <input #emailInput [attr.disabled]="disabled ? true : null" id="participantEmail" name="participantEmail" [(ngModel)]="email" (blur)="blurEmail()" class="govuk-input govuk-input--width-20"
            (keyup)="searchTerm.next($event.target.value)" type="email" />
 
     <ul *ngIf="isShowResult" class="vh-li-email">

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.html
@@ -8,7 +8,7 @@
     <label class="govuk-label" for="participantEmail">
       Email
     </label>
-    <input #emailInput id="participantEmail" name="participantEmail" [(ngModel)]="email" (blur)="blurEmail()" class="govuk-input govuk-input--width-20"
+    <input #emailInput (blur)="blur()" [attr.disabled]="disabled ? true : null" id="participantEmail" name="participantEmail" [(ngModel)]="email" (blur)="blurEmail()" class="govuk-input govuk-input--width-20"
            (keyup)="searchTerm.next($event.target.value)" type="email" />
 
     <ul *ngIf="isShowResult" class="vh-li-email">

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.spec.ts
@@ -125,7 +125,7 @@ describe('SeachEmailComponent', () => {
 
     const emailEl = fixture.debugElement.query(By.css('#participantEmail'));
 
-    component.setEmailDisabled(true);
+    component.disabled = true;
     tick(600);
     fixture.detectChanges();
     expect(emailEl.nativeElement.disabled).toBeTruthy();
@@ -133,10 +133,10 @@ describe('SeachEmailComponent', () => {
   it('should enable email address', fakeAsync(() => {
     fixture.detectChanges();
     const emailEl = fixture.debugElement.query(By.css('#participantEmail'));
-    component.setEmailDisabled(true);
+    component.disabled = true;
     tick(600);
     fixture.detectChanges();
-    component.setEmailDisabled(false);
+    component.disabled = false;
     tick(600);
     fixture.detectChanges();
     expect(emailEl.nativeElement.disabled).toBeFalsy();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.spec.ts
@@ -107,8 +107,7 @@ describe('SeachEmailComponent', () => {
   });
   it('should close drop down on the click outside', () => {
     component.isShowResult = true;
-    const elem = fixture.debugElement.nativeElement.querySelector('document');
-    component.clickedOutside(elem);
+    component.blur();
     expect(component.isShowResult).toBeFalsy();
   });
   it('select item should emit event participant found', () => {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.ts
@@ -22,7 +22,7 @@ export class SearchEmailComponent implements OnInit {
   isValidEmail = true;
 
   @Input()
-  disabled: boolean = true;
+  disabled = true;
 
   @Output()
   findParticipant = new EventEmitter<ParticipantModel>();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostListener, Output, ViewChild, OnInit } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostListener, Output, ViewChild, OnInit, Input } from '@angular/core';
 import { Subject } from 'rxjs';
 import { PersonResponse } from '../../services/clients/api-client';
 import { Constants } from '../../common/constants';
@@ -20,6 +20,10 @@ export class SearchEmailComponent implements OnInit {
   notFoundParticipant = false;
   email = '';
   isValidEmail = true;
+
+  @Input()
+  disabled: boolean = true;
+
   @Output()
   findParticipant = new EventEmitter<ParticipantModel>();
 
@@ -29,11 +33,7 @@ export class SearchEmailComponent implements OnInit {
   @Output()
   emailChanged = new EventEmitter<string>();
 
-  @ViewChild('emailInput')
-  emailInput: ElementRef;
-
-  constructor(private searchService: SearchService, private elRef: ElementRef) {
-  }
+  constructor(private searchService: SearchService) {}
 
   ngOnInit() {
     this.searchService.search(this.searchTerm)
@@ -79,7 +79,6 @@ export class SearchEmailComponent implements OnInit {
     selectedResult.is_exist_person = true;
     this.isShowResult = false;
     this.findParticipant.emit(selectedResult);
-    this.setEmailDisabled(true);
   }
 
   validateEmail() {
@@ -89,22 +88,8 @@ export class SearchEmailComponent implements OnInit {
     return this.isValidEmail;
   }
 
-  @HostListener('document:click', ['$event.target'])
-  clickedOutside(targetElement) {
-    const clickedInside = this.elRef.nativeElement.contains(targetElement);
-    if (!clickedInside) {
-      this.isShowResult = false;
-    }
-  }
-
-  setEmailDisabled(value: boolean) {
-    if (!value) {
-      this.emailInput.nativeElement.removeAttribute('disabled');
-    } else {
-      setTimeout(() => {
-        this.emailInput.nativeElement.setAttribute('disabled', 'true');
-      }, 500);
-    }
+  blur() {
+    this.isShowResult = false;
   }
 
   clearEmail() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
A first step of removing coded parent->child component dependency in code. Removing this and doing the binding in html instead will allow us to break apart the functionality, reducing complexity making it more testable and reducing risk for defects.

The plan is to remove the `this.searchEmail` calls entirely.

The most important thing here is trying to reduce the amount of `setTimeout` which creates temporal dependencies (for example calling a method, expecting something to be set afterwards and it's actually not until a few milliseconds have passed).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
