### PR TITLE
Added release number to saucelabs build name

### DIFF
--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Helpers/SeleniumEnvironment.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Helpers/SeleniumEnvironment.cs
@@ -47,7 +47,7 @@ namespace AdminWebsite.AcceptanceTests.Helpers
             }
 
             caps.SetCapability("name", _scenario.Title);
-            caps.SetCapability("build", $"{Environment.GetEnvironmentVariable("Build_DefinitionName")} {Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER")}-{Environment.GetEnvironmentVariable("RELEASE_ATTEMPTNUMBER")}");
+            caps.SetCapability("build", $"{Environment.GetEnvironmentVariable("Build_DefinitionName")} {Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER")}-{Environment.GetEnvironmentVariable("RELEASE_DEPLOYMENTID")}");
 #pragma warning restore 618
 
             // It can take quite a bit of time for some commands to execute remotely so this is higher than default

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Helpers/SeleniumEnvironment.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Helpers/SeleniumEnvironment.cs
@@ -47,7 +47,7 @@ namespace AdminWebsite.AcceptanceTests.Helpers
             }
 
             caps.SetCapability("name", _scenario.Title);
-            caps.SetCapability("build", $"{Environment.GetEnvironmentVariable("Build_DefinitionName")} {Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER")}-{Environment.GetEnvironmentVariable("RELEASE_DEPLOYMENTID")}");
+            caps.SetCapability("build", $"{Environment.GetEnvironmentVariable("Build_DefinitionName")} {Environment.GetEnvironmentVariable("RELEASE_RELEASENAME")}");
 #pragma warning restore 618
 
             // It can take quite a bit of time for some commands to execute remotely so this is higher than default

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Helpers/SeleniumEnvironment.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Helpers/SeleniumEnvironment.cs
@@ -47,7 +47,7 @@ namespace AdminWebsite.AcceptanceTests.Helpers
             }
 
             caps.SetCapability("name", _scenario.Title);
-            caps.SetCapability("build", $"{Environment.GetEnvironmentVariable("Build_DefinitionName")} {Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER")}-{Environment.GetEnvironmentVariable("Release.ReleaseId")}");
+            caps.SetCapability("build", $"{Environment.GetEnvironmentVariable("Build_DefinitionName")} {Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER")}-{Environment.GetEnvironmentVariable("RELEASE_ATTEMPTNUMBER")}");
 #pragma warning restore 618
 
             // It can take quite a bit of time for some commands to execute remotely so this is higher than default

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Helpers/SeleniumEnvironment.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Helpers/SeleniumEnvironment.cs
@@ -47,7 +47,7 @@ namespace AdminWebsite.AcceptanceTests.Helpers
             }
 
             caps.SetCapability("name", _scenario.Title);
-            caps.SetCapability("build", $"{Environment.GetEnvironmentVariable("Build_DefinitionName")} {Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER")}");
+            caps.SetCapability("build", $"{Environment.GetEnvironmentVariable("Build_DefinitionName")} {Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER")}-{Environment.GetEnvironmentVariable("Release.ReleaseId")}");
 #pragma warning restore 618
 
             // It can take quite a bit of time for some commands to execute remotely so this is higher than default


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
Right now each deployment of a release overwrites the previous run in saucelabs. This means that it is very hard to track down the results of a de-deployment as it will be logged together with the previous release instead of the new one.  For example:

![image](https://user-images.githubusercontent.com/8461739/60494605-05a9db00-9ca7-11e9-9abc-90db37f2ce73.png)

actually contains the result of this deployment:

![image](https://user-images.githubusercontent.com/8461739/60498305-3e997e00-9cae-11e9-923c-83c1052b874f.png)


Which of course is pretty hard to track down. So I simply added in the release number to the build name as well which should suffix the saucelab log entry with a `-x` for each build. Like this:

![image](https://user-images.githubusercontent.com/8461739/60498266-2e819e80-9cae-11e9-9c5c-fb3d3bbe1c09.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
