### PR TITLE
Changed selenium accessors from methods to properties for better reporting

### DIFF
--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Pages/AddParticipants.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Pages/AddParticipants.cs
@@ -32,11 +32,11 @@ namespace AdminWebsite.AcceptanceTests.Pages
         public string PartyErrorMessage() => GetElementText(By.Id("party-error"));
         public string RoleErrorMessage() => GetElementText(By.Id("role-error"));
         public IEnumerable<string> ParticipantPageErrorMessages() => Items(By.XPath("//*[@class='govuk-list govuk-error-summary__list']/li"));
-        public bool PartyField() => IsElementEnabled(By.Id("party"));
-        public bool RoleField() => IsElementEnabled(By.Id("role"));
-        public bool Email() => IsElementEnabled(By.Id("participantEmail"));
-        public bool Firstname() => IsElementEnabled(By.Id("firstName"));
-        public bool Lastname() => IsElementEnabled(By.Id("lastName"));
+        public bool PartyFieldEnabled => IsElementEnabled(By.Id("party"));
+        public bool RoleFieldEnabled => IsElementEnabled(By.Id("role"));
+        public bool EmailEnabled => IsElementEnabled(By.Id("participantEmail"));
+        public bool FirstnameEnabled => IsElementEnabled(By.Id("firstName"));
+        public bool LastnameEnabled => IsElementEnabled(By.Id("lastName"));
         public void HouseNumber(string houseNumber) => ClearFieldInputValues(By.Id("houseNumber"), houseNumber);
         public void Street(string street) => ClearFieldInputValues(By.Id("street"), street);
         public void City(string city) => ClearFieldInputValues(By.Id("city"), city);

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Steps/AddParticipantsSteps.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Steps/AddParticipantsSteps.cs
@@ -86,7 +86,7 @@ namespace AdminWebsite.AcceptanceTests.Steps
                 if (!tag.Contains("ExistingPerson"))
                 {
                     Address();
-                }                
+                }
             }
             _addParticipant.AddParticipantButton();
         }
@@ -158,7 +158,7 @@ namespace AdminWebsite.AcceptanceTests.Steps
                 case (TestData.AddParticipants.Respondent):
                     _addParticipant.RoleList().Should().BeEquivalentTo(TestData.AddParticipants.RespondentRole);
                     break;
-            }        
+            }
             _addParticipant.AddItems<string>("Role", _addParticipant.GetSelectedRole());
             AddParticpantDetails();
             ClickAddParticipantsButton();
@@ -176,7 +176,7 @@ namespace AdminWebsite.AcceptanceTests.Steps
             else
             {
                 actualResult.Should().Be(expectedResult.Trim());
-            }            
+            }
         }
         public void AddParticpantDetails()
         {
@@ -191,11 +191,11 @@ namespace AdminWebsite.AcceptanceTests.Steps
         {
             if (!_addParticipant.RoleValue().Contains(RoleType.Solicitor.ToString()))
                 Address();
-            _addParticipant.PartyField().Should().BeFalse();
-            _addParticipant.RoleField().Should().BeFalse();
-            _addParticipant.Email().Should().BeFalse();
-            _addParticipant.Firstname().Should().BeFalse();
-            _addParticipant.Lastname().Should().BeFalse();
+            _addParticipant.PartyFieldEnabled.Should().BeFalse();
+            _addParticipant.RoleFieldEnabled.Should().BeFalse();
+            _addParticipant.EmailEnabled.Should().BeFalse();
+            _addParticipant.FirstnameEnabled.Should().BeFalse();
+            _addParticipant.LastnameEnabled.Should().BeFalse();
         }
         private void Address()
         {
@@ -235,9 +235,9 @@ namespace AdminWebsite.AcceptanceTests.Steps
             _addParticipant.ParticipantEmail(email.Substring(0, 3));
             _addParticipant.ExistingParticipant(email);
             _addParticipant.DisplayName(TestData.AddParticipants.DisplayName);
-            _addParticipant.Email().Should().BeFalse();
-            _addParticipant.Firstname().Should().BeFalse();
-            _addParticipant.Lastname().Should().BeFalse();
+            _addParticipant.EmailEnabled.Should().BeFalse();
+            _addParticipant.FirstnameEnabled.Should().BeFalse();
+            _addParticipant.LastnameEnabled.Should().BeFalse();
             _addParticipant.GetFieldValue("phone").Should().NotBeNullOrEmpty();
             _addParticipant.GetFieldValue("houseNumber").Should().NotBeNullOrEmpty();
             _addParticipant.GetFieldValue("street").Should().NotBeNullOrEmpty();


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
I've found on a failure of acceptance test that it's very hard to read out what's actually going wrong. This is because the fluent assertion doesn't play nicely with methods so I've switched over to properties instead.

Compare this error output from before:
<img width="755" alt="without_properties" src="https://user-images.githubusercontent.com/8461739/60503717-2d556f00-9cb8-11e9-8031-5e6571af4393.png">

To this output afterwards:
<img width="532" alt="enabled_properties" src="https://user-images.githubusercontent.com/8461739/60503720-30505f80-9cb8-11e9-8f82-e2a0f8c036ee.png">


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
