### PR TITLE
Removed pressing the do not stay signed in button

### DIFF
--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Pages/MicrosoftLoginPage.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Pages/MicrosoftLoginPage.cs
@@ -28,7 +28,6 @@ namespace AdminWebsite.AcceptanceTests.Pages
             NextButton();
             EnterPassword(password);
             SignInButton();
-            DontStaySignedIn();
         }
 
         public void EnterUsername(string username)
@@ -45,10 +44,9 @@ namespace AdminWebsite.AcceptanceTests.Pages
             _context.NgDriver.WaitUntilElementVisible(_passwordfield).Clear();
             _context.NgDriver.WaitUntilElementVisible(_passwordfield).SendKeys(password);
         }
-        
+
         public void NextButton() => _context.NgDriver.WaitUntilElementVisible(_next).Click();
         public void SignInButton() => _context.NgDriver.WaitUntilElementVisible(_signIn).Click();
-        public void DontStaySignedIn() => _context.NgDriver.WaitUntilElementVisible(_noButton).Click();
         public void SignInTitle()
         {
             _context.Retry(() => _context.NgDriver.Title.Trim().Should().Be("Sign in to your account"));


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
Yesterday 4/7, the option to choose to "stay signed in" when logging in on the microsoft portal was removed. This breaks all tests since they expect this button to appear.

This PR removes it.

See related:
https://github.com/hmcts/vh-video-web/pull/84

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
