### PR TITLE
Fix pop up warning after edit and save, extra space before comma

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
@@ -178,6 +178,7 @@ export class SummaryComponent implements OnInit {
     this.hearingService.updateHearing(this.hearing)
       .subscribe((hearingDetailsResponse: HearingDetailsResponse) => {
         this.showWaitSaving = false;
+        this.hearingService.setBookingHasChanged(false);
         this.router.navigate([PageUrls.BookingDetails]);
       }, error => {
         this.setError(error);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/participant-details/participant-details.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/participant-details/participant-details.component.html
@@ -17,8 +17,7 @@
     <div *ngIf="participant?.HearingRoleName !== 'Judge'">
       {{participant?.fullName}}
       <div [attr.id]="'participant_role' + participant?.IndexInList" class="govuk-hint">
-        {{participant?.HearingRoleName}}
-        <span *ngIf="participant.isRepresent">, representing</span>
+        {{participant?.HearingRoleName}}<span *ngIf="participant.isRepresent">, representing</span>
         <div class="vh-text-color-black">{{participant.Representee}}</div>
       </div>
     </div>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-4967
https://tools.hmcts.net/jira/browse/VIH-5008
### Change description ###
Removed extra space before comma in participant details
Don't show pop up warning if changes are saved after edit heading details.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
