### PR TITLE
Fix for UserAccount casting error in 1.0.1+48 release

### DIFF
--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Steps/DashboardSteps.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Steps/DashboardSteps.cs
@@ -1,4 +1,5 @@
-﻿using AdminWebsite.AcceptanceTests.Helpers;
+﻿using AdminWebsite.AcceptanceTests.Configuration;
+using AdminWebsite.AcceptanceTests.Helpers;
 using AdminWebsite.AcceptanceTests.Pages;
 using FluentAssertions;
 using TechTalk.SpecFlow;
@@ -21,7 +22,7 @@ namespace AdminWebsite.AcceptanceTests.Steps
         public void ThenBookAVideoHearingPanelIsDisplayed(string panelText)
         {
             var panels = _dashboard.VhPanelTitle();
-            switch (_scenarioContext.Get<string>("User"))
+            switch (_scenarioContext.Get<UserAccount>("User").Role)
             {
                 case "VH Officer":
                     panels.Count.Should().Be(2);

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Steps/HearingDetailsSteps.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Steps/HearingDetailsSteps.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using AdminWebsite.AcceptanceTests.Contexts;
 using TechTalk.SpecFlow;
+using AdminWebsite.AcceptanceTests.Configuration;
 
 namespace AdminWebsite.AcceptanceTests.Steps
 {
@@ -90,7 +91,7 @@ namespace AdminWebsite.AcceptanceTests.Steps
         [Then(@"case type dropdown should not be populated")]
         public void ThenCaseTypeDropdownShouldNotBePopulated()
         {
-            switch (_scenarioContext.Get<string>("User"))
+            switch (_scenarioContext.Get<UserAccount>("User").Role)
             {
                 case "CaseAdminFinRemedyCivilMoneyClaims":
                     _hearingDetails.CaseTypesList().ToList().Count.Should().Be(2);


### PR DESCRIPTION
### Change description ###
Fix for UserAccount casting error in 1.0.1+48 release

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
