### PR TITLE
VIH-7144 use activeElement instead of :focus

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/change-password/change-password.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/change-password/change-password.component.spec.ts
@@ -76,9 +76,10 @@ describe('ChangePasswordComponent', () => {
     });
     it('should input box to have focus if the input is invalid', async () => {
         component.goToDiv('userName');
-        const input = fixture.nativeElement.querySelector('#userName:focus');
+        const input = fixture.nativeElement.querySelector('#userName');
+        const activeElement = document.activeElement;
         fixture.detectChanges();
-        expect(input).toBeTruthy();
+        expect(input).toBe(activeElement);
     });
     it('should on destroy unsubscribe the subscriptions', () => {
         component.userName.setValue('user.name@domain.com');


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-7144

### Change description ###

This test was failing due to the :focus selector returning undefined. Using document.activeElement instead.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
