### PR TITLE
VIH-7320 change how representatives are determined

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participants-list/participants-list.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participants-list/participants-list.component.html
@@ -1,8 +1,8 @@
 <div id="roundedborder">
   <h3 class="govuk-heading-m">{{ isEditMode ? 'Participants' : 'Participants added' }}</h3>
   <div class="vhtable" id="participants-list">
-    <div *ngFor="let pat of participants">
-      <div *ngIf="pat.is_judge">
+    <div *ngFor="let p of participants">
+      <div *ngIf="p.is_judge">
         <div class="govuk-grid-row vh-row">
           <div class="govuk-grid-column-one-third vh-image-15">
             <img
@@ -14,11 +14,11 @@
             />
           </div>
           <div class="govuk-grid-column-one-half vh-image-50 vh-wrap-text">
-            {{ pat.title === 'Judge' ? '' : pat.title }} {{ pat.display_name }}
+            {{ p.title === 'Judge' ? '' : p.title }} {{ p.display_name }}
             <div>
               <strong>Judge</strong>
             </div>
-            <div class="govuk-hint vh-wrap" id="judge-name">{{ pat.email }}</div>
+            <div class="govuk-hint vh-wrap" id="judge-name">{{ p.email }}</div>
           </div>
           <div class="govuk-grid-column-one-third vhtable-cell" *ngIf="isSummaryPage">
             <a [routerLink]="['/assign-judge']" class="vhlink" (click)="editJudge()">Change</a>
@@ -31,24 +31,24 @@
       </div>
     </div>
 
-    <div *ngFor="let pat of participants">
-      <div *ngIf="!pat.is_judge">
+    <div *ngFor="let p of participants">
+      <div *ngIf="!p.is_judge">
         <div class="govuk-grid-row vh-row">
           <div class="govuk-grid-column-two-thirds vhtable-header">
-            {{ pat.title }} {{ pat.first_name }} {{ pat.last_name }}
-            <div *ngIf="pat.hearing_role_name === 'Representative'; else notRepresenting">
+            {{ p.title }} {{ p.first_name }} {{ p.last_name }}
+            <div *ngIf="p.isRepresentative">
               <span>Representing</span>
+              <div>
+                <strong>{{ p.representee }}</strong>
+              </div>
             </div>
-            <ng-template #notRepresenting>
-              {{ pat.hearing_role_name }}
-            </ng-template>
             <div>
-              <strong>{{ pat.representee }}</strong>
+              {{ p.case_role_name }}
             </div>
           </div>
           <div class="govuk-grid-column-one-third vhtable-cell" *ngIf="isEditRemoveVisible">
-            <a class="vhlink" href="javascript:void(0)" (click)="editParticipant(pat.email)">Edit</a>
-            <a class="vhlink" href="javascript:void(0)" (click)="removeParticipant(pat.email)">Remove</a>
+            <a class="vhlink" href="javascript:void(0)" (click)="editParticipant(p.email)">Edit</a>
+            <a class="vhlink" href="javascript:void(0)" (click)="removeParticipant(p.email)">Remove</a>
           </div>
         </div>
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participants-list/participants-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participants-list/participants-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, SimpleChanges } from '@angular/core';
 import { Router } from '@angular/router';
 import { Logger } from 'src/app/services/logger';
 import { PageUrls } from 'src/app/shared/page-url.constants';
@@ -13,7 +13,7 @@ import { BookingService } from '../../services/booking.service';
 export class ParticipantsListComponent implements OnInit {
     private readonly loggerPrefix = '[ParticipantsList] -';
     @Input()
-    participants: ParticipantModel[];
+    participants: (ParticipantModel & { isRepresentative: boolean })[];
 
     $selectedForEdit: EventEmitter<string>;
     $selectedForRemove: EventEmitter<string>;
@@ -26,6 +26,12 @@ export class ParticipantsListComponent implements OnInit {
     constructor(private bookingService: BookingService, private router: Router, private logger: Logger) {
         this.$selectedForEdit = new EventEmitter<string>();
         this.$selectedForRemove = new EventEmitter<string>();
+    }
+
+    ngOnChanges(changes: SimpleChanges) {
+        (changes.participants.currentValue as (ParticipantModel & { isRepresentative: boolean })[]).forEach(p => {
+            p.isRepresentative = !!p.representee;
+        });
     }
 
     ngOnInit() {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.ts
@@ -64,9 +64,7 @@ export class ParticipantDetailsModel {
     }
 
     get isRepresenting() {
-        return (
-            this.HearingRoleName && this.HearingRoleName.indexOf('Representative') > -1 && this.Representee && this.Representee.length > 0
-        );
+        return !!this.Representee;
     }
 
     showCaseRole(): boolean {


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-7320

### Change description ###

Consider a participant a representative if the have a representee instead of based on their hearing role name. Currently, a participant is only considered a representative if they have the hearing_role_name "Representative", which causes an incorrect UI for barristers & other reps.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
