### PR TITLE
VIH-7529 Use Ejud Users for tests

### DIFF
--- a/AdminWebsite/AdminWebsite.AcceptanceTests/AdminWebsite.AcceptanceTests.csproj
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/AdminWebsite.AcceptanceTests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="NotificationApi.Client" Version="1.24.9" />
     <PackageReference Include="Notify" Version="4.0.0" />
-    <PackageReference Include="TestApi.Client" Version="1.25.0" />
+    <PackageReference Include="TestApi.Client" Version="1.25.2" />
     <PackageReference Include="VH.AcceptanceTests.Common" Version="1.21.30" />
   </ItemGroup>
 

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Configuration/AdminWebConfig.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Configuration/AdminWebConfig.cs
@@ -14,5 +14,6 @@ namespace AdminWebsite.AcceptanceTests.Configuration
 
         public KinlyConfiguration KinlyConfiguration { get; set; }
         public NotifyConfiguration NotifyConfiguration { get; set; }
+        public bool UsingEjud { get; set; }
     }
 }

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Hooks/ConfigHooks.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Hooks/ConfigHooks.cs
@@ -41,6 +41,7 @@ namespace AdminWebsite.AcceptanceTests.Hooks
             RegisterDefaultData(context);
             RegisterHearingServices(context);
             RegisterIsLive(context);
+            RegisterUsingEjud(context);
             RegisterWowzaSettings(context);
             RegisterSauceLabsSettings(context);
             RegisterKinlySettings(context);
@@ -97,6 +98,11 @@ namespace AdminWebsite.AcceptanceTests.Hooks
         {
             context.WebConfig.IsLive = _configRoot.GetValue<bool>("IsLive");
             context.WebConfig.Should().NotBeNull();
+        }
+
+        private void RegisterUsingEjud(TestContext context)
+        {
+            context.WebConfig.UsingEjud = _configRoot.GetValue<bool>("UsingEjud");
         }
 
         private void RegisterWowzaSettings(TestContext context)

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/Hooks/DataHooks.cs
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/Hooks/DataHooks.cs
@@ -73,6 +73,7 @@ namespace AdminWebsite.AcceptanceTests.Hooks
                 Application = Application.AdminWeb,
                 ExpiryInMinutes = ALLOCATE_USERS_FOR_MINUTES,
                 IsProdUser = _c.WebConfig.IsLive,
+                IsEjud = _c.WebConfig.UsingEjud,
                 TestType = TestType.Automated,
                 UserTypes = userTypes
             };

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/appsettings.json
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/appsettings.json
@@ -12,6 +12,7 @@
     "PostLogoutRedirectUri": "https://localhost:5400/"
   },
   "IsLive": false,
+  "UsingEjud": true,
   "Saucelabs": {
     "Username": "",
     "AccessKey": ""

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/appsettings.json
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/appsettings.json
@@ -12,7 +12,7 @@
     "PostLogoutRedirectUri": "https://localhost:5400/"
   },
   "IsLive": false,
-  "UsingEjud": true,
+  "UsingEjud": false,
   "Saucelabs": {
     "Username": "",
     "AccessKey": ""

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/packages.lock.json
@@ -27,9 +27,9 @@
       },
       "TestApi.Client": {
         "type": "Direct",
-        "requested": "[1.25.0, )",
-        "resolved": "1.25.0",
-        "contentHash": "uAjxNQ/veS2s6wBk4yg0Xuy0qKXPj6er+jdFTYTGxAZc1/uy7l4u7RIiDnzH1OW651d2FiDUrS5asm+GxsSXLg==",
+        "requested": "[1.25.2, )",
+        "resolved": "1.25.2",
+        "contentHash": "wKSnUyBBmLkaG8SzX0NHteELDzTc6h/b1PYx85AS1BFnVygaf4Ng337p636QcHB8WIfjDSC7bvxI4z5Qigwfwg==",
         "dependencies": {
           "BookingsApi.Client": "1.24.26",
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",

--- a/azure-pipelines.beta.yml
+++ b/azure-pipelines.beta.yml
@@ -319,5 +319,9 @@ stages:
             value: $(wowza_storageAccountKey)
           - name: WowzaConfiguration:StorageContainerName
             value: $(wowza_storageContainerName)
+            
+          # Ejud - test setting only
+          - name: UsingEjud
+            value: $(UsingEjud)
         runMultiDeviceTests: true
         deviceConfiguration: ${{ parameters.deviceConfiguration }}

--- a/azure-pipelines.nightly.yml
+++ b/azure-pipelines.nightly.yml
@@ -379,5 +379,9 @@ stages:
             value: $(wowza_storageAccountKey)
           - name: WowzaConfiguration:StorageContainerName
             value: $(wowza_storageContainerName)
+            
+          # Ejud - test setting only
+          - name: UsingEjud
+            value: $(UsingEjud)
         runMultiDeviceTests: true
         deviceConfiguration: ${{ parameters.deviceConfiguration }}

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -321,3 +321,7 @@ stages:
             value: $(wowza_storageAccountKey)
           - name: WowzaConfiguration:StorageContainerName
             value: $(wowza_storageContainerName)
+
+          # Ejud - test setting only
+          - name: UsingEjud
+            value: $(UsingEjud)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,6 +122,10 @@ parameters:
     value: $(wowza_storageAccountKey)
   - name: WowzaConfiguration:StorageContainerName
     value: $(wowza_storageContainerName)
+    
+  # Ejud - test setting only
+  - name: UsingEjud
+    value: $(UsingEjud)
 
 - name: appSettings
   type: object


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-7529


### Change description ###
- Allow tests to run with eJud Test Users
- Added a config setting to turn this on and off if eJud is unavailable - DEFAULTED TO OFF UNTIL ITS READY IN ADMIN WEB


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
