### PR TITLE
VIH-7571 amend notify emails to add join by tel details

### DIFF
--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
@@ -40,7 +40,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<IPollyRetryService> _pollyRetryServiceMock;
         private Mock<INotificationApiClient> _notificationApiMock;
         private Mock<ILogger<HearingsService>> _participantGroupLogger;
-        private Mock<IConferencesService> _conferencesServiceMock;
+        private Mock<IConferenceDetailsService> _conferencesServiceMock;
         private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
         private Mock<KinlyConfiguration> _kinlyConfigurationMock;
 
@@ -57,7 +57,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _userIdentity = new Mock<IUserIdentity>();
             _userAccountServiceLogger = new Mock<ILogger<UserAccountService>>();
             _notificationApiMock = new Mock<INotificationApiClient>();
-            _conferencesServiceMock = new Mock<IConferencesService>();
+            _conferencesServiceMock = new Mock<IConferenceDetailsService>();
 
             _conferencesServiceMock.Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
                 .ReturnsAsync(new ConferenceDetailsResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
@@ -70,7 +70,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
                 _userAccountService, _notificationApiMock.Object, _videoApiMock.Object, _bookingsApiClient.Object,
-                _participantGroupLogger.Object);
+                _participantGroupLogger.Object, _kinlyOptionsMock.Object);
 
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
                 _userIdentity.Object,
@@ -78,8 +78,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>(),
-                _kinlyOptionsMock.Object);
+                Mock.Of<IPublicHolidayRetriever>());
 
             InitHearingForTest();
         }

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
@@ -22,6 +22,8 @@ using UserApi.Client;
 using UserApi.Contract.Requests;
 using UserApi.Contract.Responses;
 using VideoApi.Client;
+using Microsoft.Extensions.Options;
+using AdminWebsite.Configuration;
 
 namespace AdminWebsite.UnitTests.Controllers.HearingsController
 {
@@ -37,6 +39,9 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<IPollyRetryService> _pollyRetryServiceMock;
         private Mock<INotificationApiClient> _notificationApiMock;
         private Mock<ILogger<HearingsService>> _participantGroupLogger;
+        private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
+        private Mock<KinlyConfiguration> _kinlyConfigurationMock;
+
         private IHearingsService _hearingsService;
 
         private AdminWebsite.Controllers.HearingsController _controller;
@@ -50,6 +55,10 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _userIdentity = new Mock<IUserIdentity>();
             _userAccountServiceLogger = new Mock<ILogger<UserAccountService>>();
             _notificationApiMock = new Mock<INotificationApiClient>();
+
+            _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
+            _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
+            _kinlyOptionsMock.Setup((op) => op.Value).Returns(_kinlyConfigurationMock.Object);
 
             _userAccountService = new UserAccountService(_userApiClient.Object, _bookingsApiClient.Object,
                 _notificationApiMock.Object, _userAccountServiceLogger.Object);
@@ -69,7 +78,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>());
+                Mock.Of<IPublicHolidayRetriever>(),
+                _kinlyOptionsMock.Object);
 
             InitHearingForTest();
         }

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/CancelHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/CancelHearingTests.cs
@@ -56,7 +56,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
                 _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object,
-                _bookingsApiClient.Object, _participantGroupLogger.Object);
+                _bookingsApiClient.Object, _participantGroupLogger.Object,
+                _kinlyOptionsMock.Object);
 
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
                 _userIdentity.Object,
@@ -64,8 +65,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>(),
-                _kinlyOptionsMock.Object);
+                Mock.Of<IPublicHolidayRetriever>());
 
             _guid = Guid.NewGuid();
 

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/CancelHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/CancelHearingTests.cs
@@ -15,6 +15,8 @@ using BookingsApi.Client;
 using BookingsApi.Contract.Requests;
 using BookingsApi.Contract.Requests.Enums;
 using VideoApi.Client;
+using Microsoft.Extensions.Options;
+using AdminWebsite.Configuration;
 
 namespace AdminWebsite.UnitTests.Controllers.HearingsController
 {
@@ -31,6 +33,9 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<IPollyRetryService> _pollyRetryServiceMock;
         private Mock<INotificationApiClient> _notificationApiMock;
         private Mock<ILogger<HearingsService>> _participantGroupLogger;
+        private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
+        private Mock<KinlyConfiguration> _kinlyConfigurationMock;
+
         private IHearingsService _hearingsService;
 
         [SetUp]
@@ -44,6 +49,10 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
             _notificationApiMock = new Mock<INotificationApiClient>();
 
+            _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
+            _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
+            _kinlyOptionsMock.Setup((op) => op.Value).Returns(_kinlyConfigurationMock.Object);
+
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
                 _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object,
@@ -55,7 +64,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>());
+                Mock.Of<IPublicHolidayRetriever>(),
+                _kinlyOptionsMock.Object);
 
             _guid = Guid.NewGuid();
 

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/CancelHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/CancelHearingTests.cs
@@ -35,6 +35,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<ILogger<HearingsService>> _participantGroupLogger;
         private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
         private Mock<KinlyConfiguration> _kinlyConfigurationMock;
+        private Mock<IConferencesService> _conferencesServiceMock;
 
         private IHearingsService _hearingsService;
 
@@ -48,6 +49,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiMock = new Mock<IVideoApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
             _notificationApiMock = new Mock<INotificationApiClient>();
+            _conferencesServiceMock = new Mock<IConferencesService>();
 
             _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
             _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
@@ -55,9 +57,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
-                _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object,
-                _bookingsApiClient.Object, _participantGroupLogger.Object,
-                _kinlyOptionsMock.Object);
+                _userAccountService.Object, _notificationApiMock.Object,
+                _bookingsApiClient.Object, _participantGroupLogger.Object, _conferencesServiceMock.Object, _kinlyOptionsMock.Object);
 
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
                 _userIdentity.Object,
@@ -65,6 +66,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
+                _conferencesServiceMock.Object,
                 Mock.Of<IPublicHolidayRetriever>());
 
             _guid = Guid.NewGuid();

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/CancelHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/CancelHearingTests.cs
@@ -35,7 +35,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<ILogger<HearingsService>> _participantGroupLogger;
         private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
         private Mock<KinlyConfiguration> _kinlyConfigurationMock;
-        private Mock<IConferencesService> _conferencesServiceMock;
+        private Mock<IConferenceDetailsService> _conferencesServiceMock;
 
         private IHearingsService _hearingsService;
 
@@ -49,7 +49,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiMock = new Mock<IVideoApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
             _notificationApiMock = new Mock<INotificationApiClient>();
-            _conferencesServiceMock = new Mock<IConferencesService>();
+            _conferencesServiceMock = new Mock<IConferenceDetailsService>();
 
             _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
             _kinlyConfigurationMock = new Mock<KinlyConfiguration>();

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using AdminWebsite.Configuration;
 using AdminWebsite.Extensions;
 using AdminWebsite.Models;
 using AdminWebsite.Security;
@@ -19,6 +20,7 @@ using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using NotificationApi.Client;
 using NotificationApi.Contract;
@@ -48,6 +50,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private HearingDetailsResponse _updatedExistingParticipantHearingOriginal;
         private Mock<IUserAccountService> _userAccountService;
         private Mock<IUserIdentity> _userIdentity;
+        private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
+        private Mock<KinlyConfiguration> _kinlyConfigurationMock;
 
         private Guid _validId;
         private Mock<IVideoApiClient> _videoApiMock;
@@ -63,6 +67,10 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _notificationApiMock = new Mock<INotificationApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
 
+            _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
+            _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
+            _kinlyOptionsMock.Setup((op) => op.Value).Returns(_kinlyConfigurationMock.Object);
+
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
                 _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object,
@@ -74,7 +82,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>());
+                Mock.Of<IPublicHolidayRetriever>(),
+                _kinlyOptionsMock.Object);
 
             _validId = Guid.NewGuid();
             _addNewParticipantRequest = new EditHearingRequest

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
@@ -73,8 +73,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
-                _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object,
-                _bookingsApiClient.Object, _participantGroupLogger.Object);
+            _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object,
+            _bookingsApiClient.Object, _participantGroupLogger.Object, _kinlyOptionsMock.Object);
 
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
                 _userIdentity.Object,
@@ -82,8 +82,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>(),
-                _kinlyOptionsMock.Object);
+                Mock.Of<IPublicHolidayRetriever>());
 
             _validId = Guid.NewGuid();
             _addNewParticipantRequest = new EditHearingRequest

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
@@ -53,7 +53,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private HearingDetailsResponse _updatedExistingParticipantHearingOriginal;
         private Mock<IUserAccountService> _userAccountService;
         private Mock<IUserIdentity> _userIdentity;
-        private Mock<IConferencesService> _conferencesServiceMock;
+        private Mock<IConferenceDetailsService> _conferencesServiceMock;
         private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
         private Mock<KinlyConfiguration> _kinlyConfigurationMock;
 
@@ -70,7 +70,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiMock = new Mock<IVideoApiClient>();
             _notificationApiMock = new Mock<INotificationApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
-            _conferencesServiceMock = new Mock<IConferencesService>();
+            _conferencesServiceMock = new Mock<IConferenceDetailsService>();
 
             _conferencesServiceMock.Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
                 .ReturnsAsync(new ConferenceDetailsResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
@@ -27,7 +27,10 @@ using NotificationApi.Contract;
 using NotificationApi.Contract.Requests;
 using NUnit.Framework;
 using VideoApi.Client;
+using VideoApi.Contract.Responses;
 using CaseResponse = BookingsApi.Contract.Responses.CaseResponse;
+using EndpointResponse = BookingsApi.Contract.Responses.EndpointResponse;
+using LinkedParticipantResponse = BookingsApi.Contract.Responses.LinkedParticipantResponse;
 
 namespace AdminWebsite.UnitTests.Controllers.HearingsController
 {
@@ -50,6 +53,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private HearingDetailsResponse _updatedExistingParticipantHearingOriginal;
         private Mock<IUserAccountService> _userAccountService;
         private Mock<IUserIdentity> _userIdentity;
+        private Mock<IConferencesService> _conferencesServiceMock;
         private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
         private Mock<KinlyConfiguration> _kinlyConfigurationMock;
 
@@ -66,15 +70,30 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiMock = new Mock<IVideoApiClient>();
             _notificationApiMock = new Mock<INotificationApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
+            _conferencesServiceMock = new Mock<IConferencesService>();
 
+            _conferencesServiceMock.Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+                .ReturnsAsync(new ConferenceDetailsResponse
+                {
+                    MeetingRoom = new MeetingRoomResponse
+                    {
+                        AdminUri = "AdminUri",
+                        JudgeUri = "JudgeUri",
+                        ParticipantUri = "ParticipantUri",
+                        PexipNode = "PexipNode",
+                        PexipSelfTestNode = "PexipSelfTestNode",
+                        TelephoneConferenceId = "expected_conference_phone_id"
+                    }
+                });
+                        
             _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
             _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
             _kinlyOptionsMock.Setup((op) => op.Value).Returns(_kinlyConfigurationMock.Object);
 
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
-            _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object,
-            _bookingsApiClient.Object, _participantGroupLogger.Object, _kinlyOptionsMock.Object);
+            _userAccountService.Object, _notificationApiMock.Object,
+            _bookingsApiClient.Object, _participantGroupLogger.Object, _conferencesServiceMock.Object, _kinlyOptionsMock.Object);
 
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
                 _userIdentity.Object,
@@ -82,6 +101,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
+                _conferencesServiceMock.Object,
                 Mock.Of<IPublicHolidayRetriever>());
 
             _validId = Guid.NewGuid();

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetHearingTests.cs
@@ -32,7 +32,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<IVideoApiClient> _videoApiMock;
         private Mock<IPollyRetryService> _pollyRetryServiceMock;
         private Mock<INotificationApiClient> _notificationApiMock;
-        private Mock<IConferencesService> _conferencesServiceMock;
+        private Mock<IConferenceDetailsService> _conferencesServiceMock;
 
         private AdminWebsite.Controllers.HearingsController _controller;
         private HearingDetailsResponse _vhExistingHearing;
@@ -55,7 +55,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
             _notificationApiMock = new Mock<INotificationApiClient>();
 
-            _conferencesServiceMock = new Mock<IConferencesService>();
+            _conferencesServiceMock = new Mock<IConferenceDetailsService>();
             _conferencesServiceMock.Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
                 .ReturnsAsync(new ConferenceDetailsResponse
                 {

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetHearingTests.cs
@@ -60,7 +60,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
                 _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object,
-                _bookingsApiClient.Object, _participantGroupLogger.Object);
+                _bookingsApiClient.Object, _participantGroupLogger.Object,
+                _kinlyOptionsMock.Object);
 
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
                 _userIdentity.Object,
@@ -68,8 +69,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>(),
-                _kinlyOptionsMock.Object);
+                Mock.Of<IPublicHolidayRetriever>());
 
             _vhExistingHearing = new HearingDetailsResponse
             {

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetHearingTests.cs
@@ -17,6 +17,8 @@ using BookingsApi.Client;
 using BookingsApi.Contract.Enums;
 using BookingsApi.Contract.Responses;
 using VideoApi.Client;
+using Microsoft.Extensions.Options;
+using AdminWebsite.Configuration;
 
 namespace AdminWebsite.UnitTests.Controllers.HearingsController
 {
@@ -37,6 +39,9 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<ILogger<HearingsService>> _participantGroupLogger;
         private IHearingsService _hearingsService;
 
+        private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
+        private Mock<KinlyConfiguration> _kinlyConfigurationMock;
+
         [SetUp]
         public void Setup()
         {
@@ -47,6 +52,10 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiMock = new Mock<IVideoApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
             _notificationApiMock = new Mock<INotificationApiClient>();
+
+            _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
+            _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
+            _kinlyOptionsMock.Setup((op) => op.Value).Returns(_kinlyConfigurationMock.Object);
 
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
@@ -59,7 +68,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>());
+                Mock.Of<IPublicHolidayRetriever>(),
+                _kinlyOptionsMock.Object);
 
             _vhExistingHearing = new HearingDetailsResponse
             {

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetTelephoneConferenceIdTest.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetTelephoneConferenceIdTest.cs
@@ -27,7 +27,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<IPollyRetryService> _pollyRetryServiceMock;
         private Mock<INotificationApiClient> _notificationApiMock;
         private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
-        private Mock<IConferencesService> _conferencesServiceMock;
+        private Mock<IConferenceDetailsService> _conferencesServiceMock;
         private Mock<KinlyConfiguration> _kinlyConfigurationMock;
 
         private AdminWebsite.Controllers.HearingsController _controller;
@@ -47,7 +47,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiMock = new Mock<IVideoApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
             _notificationApiMock = new Mock<INotificationApiClient>();
-            _conferencesServiceMock = new Mock<IConferencesService>();
+            _conferencesServiceMock = new Mock<IConferenceDetailsService>();
             
             _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
             _kinlyConfigurationMock = new Mock<KinlyConfiguration>();

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetTelephoneConferenceIdTest.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetTelephoneConferenceIdTest.cs
@@ -52,7 +52,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
-                _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object);
+                _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object,
+                _kinlyOptionsMock.Object);
 
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
                 _userIdentity.Object,
@@ -60,8 +61,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>(),
-                _kinlyOptionsMock.Object);
+                Mock.Of<IPublicHolidayRetriever>());
 
             _conference = new ConferenceDetailsResponse
             {

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetTelephoneConferenceIdTest.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetTelephoneConferenceIdTest.cs
@@ -12,6 +12,8 @@ using System;
 using BookingsApi.Client;
 using VideoApi.Client;
 using VideoApi.Contract.Responses;
+using Microsoft.Extensions.Options;
+using AdminWebsite.Configuration;
 
 namespace AdminWebsite.UnitTests.Controllers.HearingsController
 {
@@ -24,6 +26,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<IVideoApiClient> _videoApiMock;
         private Mock<IPollyRetryService> _pollyRetryServiceMock;
         private Mock<INotificationApiClient> _notificationApiMock;
+        private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
+        private Mock<KinlyConfiguration> _kinlyConfigurationMock;
 
         private AdminWebsite.Controllers.HearingsController _controller;
         private ConferenceDetailsResponse _conference;
@@ -42,6 +46,9 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiMock = new Mock<IVideoApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
             _notificationApiMock = new Mock<INotificationApiClient>();
+            _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
+            _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
+            _kinlyOptionsMock.Setup((op) => op.Value).Returns(_kinlyConfigurationMock.Object);
 
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
@@ -53,7 +60,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>());
+                Mock.Of<IPublicHolidayRetriever>(),
+                _kinlyOptionsMock.Object);
 
             _conference = new ConferenceDetailsResponse
             {

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
@@ -30,6 +30,8 @@ using EndpointResponse = BookingsApi.Contract.Responses.EndpointResponse;
 using LinkedParticipantResponse = BookingsApi.Contract.Responses.LinkedParticipantResponse;
 using CaseResponse = BookingsApi.Contract.Responses.CaseResponse;
 using LinkedParticipantType = BookingsApi.Contract.Enums.LinkedParticipantType;
+using Microsoft.Extensions.Options;
+using AdminWebsite.Configuration;
 
 namespace AdminWebsite.UnitTests.Controllers.HearingsController
 {
@@ -46,6 +48,9 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<ILogger<HearingsService>> _participantGroupLogger;
         private IHearingsService _hearingsService;
 
+        private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
+        private Mock<KinlyConfiguration> _kinlyConfigurationMock;
+
         private AdminWebsite.Controllers.HearingsController _controller;
 
         [SetUp]
@@ -59,6 +64,10 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _notificationApiMock = new Mock<INotificationApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
 
+            _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
+            _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
+            _kinlyOptionsMock.Setup((op) => op.Value).Returns(_kinlyConfigurationMock.Object);
+
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
                 _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object);
@@ -69,7 +78,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>());
+                Mock.Of<IPublicHolidayRetriever>(),
+                _kinlyOptionsMock.Object);
 
             _userAccountService
                 .Setup(x => x.UpdateParticipantUsername(It.IsAny<BookingsApi.Contract.Requests.ParticipantRequest>()))

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
@@ -70,7 +70,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
-                _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object);
+                _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object,
+                _kinlyOptionsMock.Object);
 
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
                 _userIdentity.Object,
@@ -78,8 +79,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>(),
-                _kinlyOptionsMock.Object);
+                Mock.Of<IPublicHolidayRetriever>());
 
             _userAccountService
                 .Setup(x => x.UpdateParticipantUsername(It.IsAny<BookingsApi.Contract.Requests.ParticipantRequest>()))

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
@@ -32,6 +32,7 @@ using CaseResponse = BookingsApi.Contract.Responses.CaseResponse;
 using LinkedParticipantType = BookingsApi.Contract.Enums.LinkedParticipantType;
 using Microsoft.Extensions.Options;
 using AdminWebsite.Configuration;
+using VideoApi.Contract.Responses;
 
 namespace AdminWebsite.UnitTests.Controllers.HearingsController
 {
@@ -44,6 +45,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<IVideoApiClient> _videoApiMock;
         private Mock<IPollyRetryService> _pollyRetryServiceMock;
         private Mock<INotificationApiClient> _notificationApiMock;
+        private Mock<IConferencesService> _conferencesServiceMock;
 
         private Mock<ILogger<HearingsService>> _participantGroupLogger;
         private IHearingsService _hearingsService;
@@ -63,14 +65,29 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiMock = new Mock<IVideoApiClient>();
             _notificationApiMock = new Mock<INotificationApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
+            _conferencesServiceMock = new Mock<IConferencesService>();
 
+            _conferencesServiceMock.Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+                .ReturnsAsync(new ConferenceDetailsResponse
+                {
+                    MeetingRoom = new MeetingRoomResponse
+                    {
+                        AdminUri = "AdminUri",
+                        JudgeUri = "JudgeUri",
+                        ParticipantUri = "ParticipantUri",
+                        PexipNode = "PexipNode",
+                        PexipSelfTestNode = "PexipSelfTestNode",
+                        TelephoneConferenceId = "expected_conference_phone_id"
+                    }
+                });
+            
             _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
             _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
             _kinlyOptionsMock.Setup((op) => op.Value).Returns(_kinlyConfigurationMock.Object);
 
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
-                _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object,
+                _userAccountService.Object, _notificationApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object, _conferencesServiceMock.Object,
                 _kinlyOptionsMock.Object);
 
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
@@ -79,6 +96,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
+                _conferencesServiceMock.Object,
                 Mock.Of<IPublicHolidayRetriever>());
 
             _userAccountService

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
@@ -45,7 +45,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<IVideoApiClient> _videoApiMock;
         private Mock<IPollyRetryService> _pollyRetryServiceMock;
         private Mock<INotificationApiClient> _notificationApiMock;
-        private Mock<IConferencesService> _conferencesServiceMock;
+        private Mock<IConferenceDetailsService> _conferencesServiceMock;
 
         private Mock<ILogger<HearingsService>> _participantGroupLogger;
         private IHearingsService _hearingsService;
@@ -65,7 +65,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiMock = new Mock<IVideoApiClient>();
             _notificationApiMock = new Mock<INotificationApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
-            _conferencesServiceMock = new Mock<IConferencesService>();
+            _conferencesServiceMock = new Mock<IConferenceDetailsService>();
 
             _conferencesServiceMock.Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
                 .ReturnsAsync(new ConferenceDetailsResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/SearchForAudioRecordedHearingsTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/SearchForAudioRecordedHearingsTests.cs
@@ -56,7 +56,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
-                _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object);
+                _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object,
+                _kinlyOptionsMock.Object);
 
             _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
             _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
@@ -68,8 +69,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>(),
-                _kinlyOptionsMock.Object);
+                Mock.Of<IPublicHolidayRetriever>());
 
             _vhExistingHearing = new HearingDetailsResponse
             {

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/SearchForAudioRecordedHearingsTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/SearchForAudioRecordedHearingsTests.cs
@@ -18,6 +18,8 @@ using BookingsApi.Client;
 using BookingsApi.Contract.Enums;
 using BookingsApi.Contract.Responses;
 using VideoApi.Client;
+using AdminWebsite.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace AdminWebsite.UnitTests.Controllers.HearingsController
 {
@@ -38,6 +40,9 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<ILogger<HearingsService>> _participantGroupLogger;
         private IHearingsService _hearingsService;
 
+        private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
+        private Mock<KinlyConfiguration> _kinlyConfigurationMock;
+
         [SetUp]
         public void Setup()
         {
@@ -53,13 +58,18 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
                 _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object);
 
+            _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
+            _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
+            _kinlyOptionsMock.Setup((op) => op.Value).Returns(_kinlyConfigurationMock.Object);
+
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
                 _userIdentity.Object,
                 _userAccountService.Object,
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>());
+                Mock.Of<IPublicHolidayRetriever>(),
+                _kinlyOptionsMock.Object);
 
             _vhExistingHearing = new HearingDetailsResponse
             {

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/SearchForAudioRecordedHearingsTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/SearchForAudioRecordedHearingsTests.cs
@@ -20,6 +20,7 @@ using BookingsApi.Contract.Responses;
 using VideoApi.Client;
 using AdminWebsite.Configuration;
 using Microsoft.Extensions.Options;
+using VideoApi.Contract.Responses;
 
 namespace AdminWebsite.UnitTests.Controllers.HearingsController
 {
@@ -32,6 +33,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<IVideoApiClient> _videoApiMock;
         private Mock<IPollyRetryService> _pollyRetryServiceMock;
         private Mock<INotificationApiClient> _notificationApiMock;
+        private Mock<IConferencesService> _conferencesServiceMock;
 
         private AdminWebsite.Controllers.HearingsController _controller;
         private HearingDetailsResponse _vhExistingHearing;
@@ -53,22 +55,38 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiMock = new Mock<IVideoApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
             _notificationApiMock = new Mock<INotificationApiClient>();
-
-            _participantGroupLogger = new Mock<ILogger<HearingsService>>();
-            _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
-                _userAccountService.Object, _notificationApiMock.Object, _videoApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object,
-                _kinlyOptionsMock.Object);
-
+            _conferencesServiceMock = new Mock<IConferencesService>();
+            
+            _conferencesServiceMock.Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+                .ReturnsAsync(new ConferenceDetailsResponse
+                {
+                    MeetingRoom = new MeetingRoomResponse
+                    {
+                        AdminUri = "AdminUri",
+                        JudgeUri = "JudgeUri",
+                        ParticipantUri = "ParticipantUri",
+                        PexipNode = "PexipNode",
+                        PexipSelfTestNode = "PexipSelfTestNode",
+                        TelephoneConferenceId = "expected_conference_phone_id"
+                    }
+                });
+            
             _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
             _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
             _kinlyOptionsMock.Setup((op) => op.Value).Returns(_kinlyConfigurationMock.Object);
 
+            _participantGroupLogger = new Mock<ILogger<HearingsService>>();
+            _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
+                _userAccountService.Object, _notificationApiMock.Object, _bookingsApiClient.Object, _participantGroupLogger.Object, _conferencesServiceMock.Object,
+                _kinlyOptionsMock.Object);
+            
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
                 _userIdentity.Object,
                 _userAccountService.Object,
                 _editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
+                _conferencesServiceMock.Object,
                 Mock.Of<IPublicHolidayRetriever>());
 
             _vhExistingHearing = new HearingDetailsResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/SearchForAudioRecordedHearingsTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/SearchForAudioRecordedHearingsTests.cs
@@ -33,7 +33,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private Mock<IVideoApiClient> _videoApiMock;
         private Mock<IPollyRetryService> _pollyRetryServiceMock;
         private Mock<INotificationApiClient> _notificationApiMock;
-        private Mock<IConferencesService> _conferencesServiceMock;
+        private Mock<IConferenceDetailsService> _conferencesServiceMock;
 
         private AdminWebsite.Controllers.HearingsController _controller;
         private HearingDetailsResponse _vhExistingHearing;
@@ -55,7 +55,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiMock = new Mock<IVideoApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
             _notificationApiMock = new Mock<INotificationApiClient>();
-            _conferencesServiceMock = new Mock<IConferencesService>();
+            _conferencesServiceMock = new Mock<IConferenceDetailsService>();
             
             _conferencesServiceMock.Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
                 .ReturnsAsync(new ConferenceDetailsResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
@@ -53,7 +53,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             _participantGroupLogger = new Mock<ILogger<HearingsService>>();
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
-                userAccountService.Object, _notificationApiMock.Object, _videoApiClient.Object, _bookingsApiClient.Object, _participantGroupLogger.Object);
+                userAccountService.Object, _notificationApiMock.Object, _videoApiClient.Object, _bookingsApiClient.Object, _participantGroupLogger.Object, _kinlyOptionsMock.Object);
 
             _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
             _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
@@ -65,8 +65,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>(),
-                _kinlyOptionsMock.Object);
+                Mock.Of<IPublicHolidayRetriever>());
         }
 
         [Test]

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using AdminWebsite.Configuration;
 using AdminWebsite.Extensions;
 using AdminWebsite.Models;
 using AdminWebsite.Security;
@@ -15,6 +16,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using NotificationApi.Client;
 using NotificationApi.Contract;
@@ -33,6 +35,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private readonly AdminWebsite.Controllers.HearingsController _controller;
         private readonly Mock<IPollyRetryService> _pollyRetryServiceMock;
         private readonly Mock<INotificationApiClient> _notificationApiMock;
+        private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
+        private Mock<KinlyConfiguration> _kinlyConfigurationMock;
 
         private readonly Mock<ILogger<HearingsService>> _participantGroupLogger;
         private readonly IHearingsService _hearingsService;
@@ -51,13 +55,18 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _hearingsService = new HearingsService(_pollyRetryServiceMock.Object,
                 userAccountService.Object, _notificationApiMock.Object, _videoApiClient.Object, _bookingsApiClient.Object, _participantGroupLogger.Object);
 
+            _kinlyOptionsMock = new Mock<IOptions<KinlyConfiguration>>();
+            _kinlyConfigurationMock = new Mock<KinlyConfiguration>();
+            _kinlyOptionsMock.Setup((op) => op.Value).Returns(_kinlyConfigurationMock.Object);
+
             _controller = new AdminWebsite.Controllers.HearingsController(_bookingsApiClient.Object,
                 _userIdentity.Object,
                 userAccountService.Object,
                 editHearingRequestValidator.Object,
                 new Mock<ILogger<AdminWebsite.Controllers.HearingsController>>().Object,
                 _hearingsService,
-                Mock.Of<IPublicHolidayRetriever>());
+                Mock.Of<IPublicHolidayRetriever>(),
+                _kinlyOptionsMock.Object);
         }
 
         [Test]

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
@@ -35,7 +35,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         private readonly AdminWebsite.Controllers.HearingsController _controller;
         private readonly Mock<IPollyRetryService> _pollyRetryServiceMock;
         private readonly Mock<INotificationApiClient> _notificationApiMock;
-        private Mock<IConferencesService> _conferencesServiceMock;
+        private Mock<IConferenceDetailsService> _conferencesServiceMock;
         private Mock<IOptions<KinlyConfiguration>> _kinlyOptionsMock;
         private Mock<KinlyConfiguration> _kinlyConfigurationMock;
 
@@ -51,7 +51,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _videoApiClient = new Mock<IVideoApiClient>();
             _pollyRetryServiceMock = new Mock<IPollyRetryService>();
             _notificationApiMock = new Mock<INotificationApiClient>();
-            _conferencesServiceMock = new Mock<IConferencesService>();
+            _conferencesServiceMock = new Mock<IConferenceDetailsService>();
 
             _conferencesServiceMock.Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
                 .ReturnsAsync(new ConferenceDetailsResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingAmendmentNotificationTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingAmendmentNotificationTests.cs
@@ -34,7 +34,8 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var participant = InitParticipant("Judge");
             _hearing.OtherInformation = JsonConvert.SerializeObject(new OtherInformationDetails
                 {JudgeEmail = "judge@hmcts.net", JudgePhone = "123456789"});
-
+            var expectedConferencePhoneNumber = "phone_number";
+            
             var expectedParameters = new Dictionary<string, string>
             {
                 {"case name", caseName},
@@ -44,12 +45,13 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"Old time", "11:30 AM"},
                 {"New time", "2:10 PM"},
                 {"Old Day Month Year", "10 February 2020"},
-                {"New Day Month Year", "12 October 2020"}
+                {"New Day Month Year", "12 October 2020"},
+                {"conference phone number", expectedConferencePhoneNumber}
             };
 
             var result =
                 AddNotificationRequestMapper.MapToHearingAmendmentNotification(_hearing, participant, caseName,
-                    caseNumber, oldDate, newDate);
+                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(_hearing.Id);
@@ -70,6 +72,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var caseName = "cse test";
             var caseNumber = "MBFY/17364";
             var participant = InitParticipant("Individual");
+            var expectedConferencePhoneNumber = "phone_number";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -79,12 +82,13 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"Old time", "11:30 AM"},
                 {"New time", "2:10 PM"},
                 {"Old Day Month Year", "10 February 2020"},
-                {"New Day Month Year", "12 October 2020"}
+                {"New Day Month Year", "12 October 2020"},
+                {"conference phone number", expectedConferencePhoneNumber}
             };
 
             var result =
                 AddNotificationRequestMapper.MapToHearingAmendmentNotification(_hearing, participant, caseName,
-                    caseNumber, oldDate, newDate);
+                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(_hearing.Id);
@@ -105,6 +109,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var caseName = "cse test";
             var caseNumber = "MBFY/17364";
             var participant = InitParticipant("Representative", "Random Person");
+            var expectedConferencePhoneNumber = "phone_number";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -115,12 +120,13 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"Old time", "11:30 AM"},
                 {"New time", "2:10 PM"},
                 {"Old Day Month Year", "10 February 2020"},
-                {"New Day Month Year", "12 October 2020"}
+                {"New Day Month Year", "12 October 2020"},
+                {"conference phone number", expectedConferencePhoneNumber}
             };
 
             var result =
                 AddNotificationRequestMapper.MapToHearingAmendmentNotification(_hearing, participant, caseName,
-                    caseNumber, oldDate, newDate);
+                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(_hearing.Id);
@@ -141,6 +147,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var caseName = "cse test";
             var caseNumber = "MBFY/17364";
             var participant = InitParticipant("Judicial Office Holder");
+            var expectedConferencePhoneNumber = "phone_number";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -150,12 +157,13 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"Old time", "11:30 AM"},
                 {"New time", "2:10 PM"},
                 {"Old Day Month Year", "10 February 2020"},
-                {"New Day Month Year", "12 October 2020"}
+                {"New Day Month Year", "12 October 2020"},
+                {"conference phone number", expectedConferencePhoneNumber}
             };
 
             var result =
                 AddNotificationRequestMapper.MapToHearingAmendmentNotification(_hearing, participant, caseName,
-                    caseNumber, oldDate, newDate);
+                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(_hearing.Id);

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingAmendmentNotificationTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingAmendmentNotificationTests.cs
@@ -35,6 +35,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             _hearing.OtherInformation = JsonConvert.SerializeObject(new OtherInformationDetails
                 {JudgeEmail = "judge@hmcts.net", JudgePhone = "123456789"});
             var expectedConferencePhoneNumber = "phone_number";
+            var expectedConferencePhoneId = "phone_id";
             
             var expectedParameters = new Dictionary<string, string>
             {
@@ -46,12 +47,13 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"New time", "2:10 PM"},
                 {"Old Day Month Year", "10 February 2020"},
                 {"New Day Month Year", "12 October 2020"},
-                {"conference phone number", expectedConferencePhoneNumber}
+                {"conference phone number", expectedConferencePhoneNumber},
+                {"conference phone id", expectedConferencePhoneId},
             };
 
             var result =
                 AddNotificationRequestMapper.MapToHearingAmendmentNotification(_hearing, participant, caseName,
-                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber);
+                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber, expectedConferencePhoneId);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(_hearing.Id);
@@ -73,6 +75,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var caseNumber = "MBFY/17364";
             var participant = InitParticipant("Individual");
             var expectedConferencePhoneNumber = "phone_number";
+            var expectedConferencePhoneId = "phone_id";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -83,12 +86,13 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"New time", "2:10 PM"},
                 {"Old Day Month Year", "10 February 2020"},
                 {"New Day Month Year", "12 October 2020"},
-                {"conference phone number", expectedConferencePhoneNumber}
+                {"conference phone number", expectedConferencePhoneNumber},
+                {"conference phone id", expectedConferencePhoneId}
             };
 
             var result =
                 AddNotificationRequestMapper.MapToHearingAmendmentNotification(_hearing, participant, caseName,
-                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber);
+                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber, expectedConferencePhoneId);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(_hearing.Id);
@@ -110,6 +114,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var caseNumber = "MBFY/17364";
             var participant = InitParticipant("Representative", "Random Person");
             var expectedConferencePhoneNumber = "phone_number";
+            var expectedConferencePhoneId = "phone_id";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -121,12 +126,13 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"New time", "2:10 PM"},
                 {"Old Day Month Year", "10 February 2020"},
                 {"New Day Month Year", "12 October 2020"},
-                {"conference phone number", expectedConferencePhoneNumber}
+                {"conference phone number", expectedConferencePhoneNumber},
+                {"conference phone id", expectedConferencePhoneId}
             };
 
             var result =
                 AddNotificationRequestMapper.MapToHearingAmendmentNotification(_hearing, participant, caseName,
-                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber);
+                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber, expectedConferencePhoneId);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(_hearing.Id);
@@ -148,6 +154,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var caseNumber = "MBFY/17364";
             var participant = InitParticipant("Judicial Office Holder");
             var expectedConferencePhoneNumber = "phone_number";
+            var expectedConferencePhoneId = "phone_id";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -158,12 +165,13 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"New time", "2:10 PM"},
                 {"Old Day Month Year", "10 February 2020"},
                 {"New Day Month Year", "12 October 2020"},
-                {"conference phone number", expectedConferencePhoneNumber}
+                {"conference phone number", expectedConferencePhoneNumber},
+                {"conference phone id", expectedConferencePhoneId},
             };
 
             var result =
                 AddNotificationRequestMapper.MapToHearingAmendmentNotification(_hearing, participant, caseName,
-                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber);
+                    caseNumber, oldDate, newDate, expectedConferencePhoneNumber, expectedConferencePhoneId);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(_hearing.Id);

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingAmendmentNotificationTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingAmendmentNotificationTests.cs
@@ -87,9 +87,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"Old time", "11:30 AM"},
                 {"New time", "2:10 PM"},
                 {"Old Day Month Year", "10 February 2020"},
-                {"New Day Month Year", "12 October 2020"},
-                {"conference phone number", null},
-                {"conference phone id", null}
+                {"New Day Month Year", "12 October 2020"}
             };
 
             var result =

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingConfirmationNotificationTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingConfirmationNotificationTests.cs
@@ -22,7 +22,8 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var hearing = InitHearing();
             hearing.OtherInformation = JsonConvert.SerializeObject(new OtherInformationDetails
                 {JudgeEmail = "judge@hmcts.net", JudgePhone = "123456789"});
-            
+            var expectedConferencePhoneNumber = "07703123123";
+
             var expectedParameters = new Dictionary<string, string>
             {
                 {"case name", hearing.Cases.First().Name},
@@ -30,10 +31,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"time", "2:10 PM"},
                 {"day month year", "12 October 2020"},
                 {"judge", participant.DisplayName},
-                {"courtroom account username", participant.Username}
+                {"courtroom account username", participant.Username},
+                {"conference phone number", expectedConferencePhoneNumber }
             };
             
-            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant);
+            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -51,6 +53,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var expectedNotificationType = NotificationType.HearingConfirmationLip;
             var participant = InitParticipant("Individual");
             var hearing = InitHearing();
+            var expectedConferencePhoneNumber = "07703123123";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -58,10 +61,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"case number", hearing.Cases.First().Number},
                 {"time", "2:10 PM"},
                 {"day month year", "12 October 2020"},
-                {"name", $"{participant.FirstName} {participant.LastName}"}
+                {"name", $"{participant.FirstName} {participant.LastName}"},
+                {"conference phone number", $"{expectedConferencePhoneNumber}"}
             };
             
-            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant);
+            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -79,6 +83,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var expectedNotificationType = NotificationType.HearingConfirmationRepresentative;
             var participant = InitParticipant("Representative", "Jane Doe");
             var hearing = InitHearing();
+            var expectedConferencePhoneNumber = "07703123123";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -87,11 +92,12 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"time", "2:10 PM"},
                 {"day month year", "12 October 2020"},
                 {"solicitor name", $"{participant.FirstName} {participant.LastName}"},
-                {"client name", $"{participant.Representee}"}
+                {"client name", $"{participant.Representee}"},
+                {"conference phone number", $"{expectedConferencePhoneNumber}"}
             };
-            
-            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant);
-            
+
+            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber);
+
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
             result.ParticipantId.Should().Be(participant.Id);
@@ -108,6 +114,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var expectedNotificationType = NotificationType.HearingConfirmationJoh;
             var participant = InitParticipant("Judicial Office Holder");
             var hearing = InitHearing();
+            var expectedConferencePhoneNumber = "07703123123";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -115,11 +122,12 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"case number", hearing.Cases.First().Number},
                 {"time", "2:10 PM"},
                 {"day month year", "12 October 2020"},
-                {"judicial office holder", $"{participant.FirstName} {participant.LastName}"}
+                {"judicial office holder", $"{participant.FirstName} {participant.LastName}"},
+                {"conference phone number", $"{expectedConferencePhoneNumber}"}
             };
-            
-            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant);
-            
+
+            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber);
+
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
             result.ParticipantId.Should().Be(participant.Id);

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingConfirmationNotificationTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingConfirmationNotificationTests.cs
@@ -67,9 +67,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"case number", hearing.Cases.First().Number},
                 {"time", "2:10 PM"},
                 {"day month year", "12 October 2020"},
-                {"judge", participant.DisplayName},
-                {"conference phone number", null },
-                {"conference phone id", null}
+                {"judge", participant.DisplayName}
             };
             
             var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, null, null);

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingConfirmationNotificationTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingConfirmationNotificationTests.cs
@@ -23,6 +23,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             hearing.OtherInformation = JsonConvert.SerializeObject(new OtherInformationDetails
                 {JudgeEmail = "judge@hmcts.net", JudgePhone = "123456789"});
             var expectedConferencePhoneNumber = "07703123123";
+            var expectedConferenceId = "id";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -32,10 +33,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"day month year", "12 October 2020"},
                 {"judge", participant.DisplayName},
                 {"courtroom account username", participant.Username},
-                {"conference phone number", expectedConferencePhoneNumber }
+                {"conference phone number", expectedConferencePhoneNumber },
+                {"conference phone id", $"{expectedConferenceId}"}
             };
             
-            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber);
+            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber, expectedConferenceId);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -54,6 +56,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var participant = InitParticipant("Individual");
             var hearing = InitHearing();
             var expectedConferencePhoneNumber = "07703123123";
+            var expectedConferenceId = "id";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -62,10 +65,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"time", "2:10 PM"},
                 {"day month year", "12 October 2020"},
                 {"name", $"{participant.FirstName} {participant.LastName}"},
-                {"conference phone number", $"{expectedConferencePhoneNumber}"}
+                {"conference phone number", $"{expectedConferencePhoneNumber}"},
+                {"conference phone id", $"{expectedConferenceId}"}
             };
             
-            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber);
+            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber, expectedConferenceId);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -84,6 +88,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var participant = InitParticipant("Representative", "Jane Doe");
             var hearing = InitHearing();
             var expectedConferencePhoneNumber = "07703123123";
+            var expectedConferenceId = "id";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -93,10 +98,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"day month year", "12 October 2020"},
                 {"solicitor name", $"{participant.FirstName} {participant.LastName}"},
                 {"client name", $"{participant.Representee}"},
-                {"conference phone number", $"{expectedConferencePhoneNumber}"}
+                {"conference phone number", $"{expectedConferencePhoneNumber}"},
+                {"conference phone id", $"{expectedConferenceId}"}
             };
 
-            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber);
+            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber, expectedConferenceId);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -115,6 +121,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var participant = InitParticipant("Judicial Office Holder");
             var hearing = InitHearing();
             var expectedConferencePhoneNumber = "07703123123";
+            var expectedConferenceId = "id";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -123,10 +130,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"time", "2:10 PM"},
                 {"day month year", "12 October 2020"},
                 {"judicial office holder", $"{participant.FirstName} {participant.LastName}"},
-                {"conference phone number", $"{expectedConferencePhoneNumber}"}
+                {"conference phone number", $"{expectedConferencePhoneNumber}"},
+                {"conference phone id", $"{expectedConferenceId}"}
             };
 
-            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber);
+            var result = AddNotificationRequestMapper.MapToHearingConfirmationNotification(hearing, participant, expectedConferencePhoneNumber, expectedConferenceId);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingReminderNotificationTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingReminderNotificationTests.cs
@@ -18,6 +18,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var participant = InitParticipant("Individual");
             var hearing = InitHearing();
             var expectedConferencePhoneNumber = "07703123123";
+            var expectedConferencePhoneId = "id";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -27,10 +28,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"day month year", "12 October 2020"},
                 {"name", $"{participant.FirstName} {participant.LastName}"},
                 {"username", participant.Username},
-                {"conference phone number", expectedConferencePhoneNumber }
+                {"conference phone number", expectedConferencePhoneNumber },
+                {"conference phone id", expectedConferencePhoneId }
             };
 
-            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant, expectedConferencePhoneNumber);
+            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant, expectedConferencePhoneNumber, expectedConferencePhoneId);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -49,6 +51,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var participant = InitParticipant("Representative", "Jane Doe");
             var hearing = InitHearing();
             var expectedConferencePhoneNumber = "07703123123";
+            var expectedConferencePhoneId = "id";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -59,10 +62,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"solicitor name", $"{participant.FirstName} {participant.LastName}"},
                 {"client name", $"{participant.Representee}"},
                 {"username", participant.Username},
-                {"conference phone number", expectedConferencePhoneNumber }
+                {"conference phone number", expectedConferencePhoneNumber },
+                {"conference phone id", expectedConferencePhoneId }
             };
 
-            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant, expectedConferencePhoneNumber);
+            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant, expectedConferencePhoneNumber, expectedConferencePhoneId);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -81,6 +85,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var participant = InitParticipant("Judicial Office Holder");
             var hearing = InitHearing();
             var expectedConferencePhoneNumber = "07703123123";
+            var expectedConferencePhoneId = "id";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -90,10 +95,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"day month year", "12 October 2020"},
                 {"judicial office holder", $"{participant.FirstName} {participant.LastName}"},
                 {"username", participant.Username},
-                {"conference phone number", expectedConferencePhoneNumber }
+                {"conference phone number", expectedConferencePhoneNumber },
+                {"conference phone id", expectedConferencePhoneId }
             };
 
-            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant, expectedConferencePhoneNumber);
+            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant, expectedConferencePhoneNumber, expectedConferencePhoneId);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingReminderNotificationTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToHearingReminderNotificationTests.cs
@@ -17,6 +17,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var expectedNotificationType = NotificationType.HearingReminderLip;
             var participant = InitParticipant("Individual");
             var hearing = InitHearing();
+            var expectedConferencePhoneNumber = "07703123123";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -25,10 +26,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"time", "2:10 PM"},
                 {"day month year", "12 October 2020"},
                 {"name", $"{participant.FirstName} {participant.LastName}"},
-                {"username", participant.Username}
+                {"username", participant.Username},
+                {"conference phone number", expectedConferencePhoneNumber }
             };
 
-            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant);
+            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant, expectedConferencePhoneNumber);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -46,6 +48,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var expectedNotificationType = NotificationType.HearingReminderRepresentative;
             var participant = InitParticipant("Representative", "Jane Doe");
             var hearing = InitHearing();
+            var expectedConferencePhoneNumber = "07703123123";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -55,10 +58,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"day month year", "12 October 2020"},
                 {"solicitor name", $"{participant.FirstName} {participant.LastName}"},
                 {"client name", $"{participant.Representee}"},
-                {"username", participant.Username}
+                {"username", participant.Username},
+                {"conference phone number", expectedConferencePhoneNumber }
             };
 
-            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant);
+            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant, expectedConferencePhoneNumber);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -76,6 +80,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var expectedNotificationType = NotificationType.HearingReminderJoh;
             var participant = InitParticipant("Judicial Office Holder");
             var hearing = InitHearing();
+            var expectedConferencePhoneNumber = "07703123123";
 
             var expectedParameters = new Dictionary<string, string>
             {
@@ -84,10 +89,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"time", "2:10 PM"},
                 {"day month year", "12 October 2020"},
                 {"judicial office holder", $"{participant.FirstName} {participant.LastName}"},
-                {"username", participant.Username}
+                {"username", participant.Username},
+                {"conference phone number", expectedConferencePhoneNumber }
             };
 
-            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant);
+            var result = AddNotificationRequestMapper.MapToHearingReminderNotification(hearing, participant, expectedConferencePhoneNumber);
 
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToMultiDayHearingConfirmationNotificationTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToMultiDayHearingConfirmationNotificationTests.cs
@@ -69,9 +69,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"time", "2:10 PM"},
                 {"Start Day Month Year", "12 October 2020"},
                 {"judge", participant.DisplayName},
-                {"number of days", "4"},
-                {"conference phone number", null},
-                {"conference phone id", null}
+                {"number of days", "4"}
             };
             
             var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, null, null);

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToMultiDayHearingConfirmationNotificationTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToMultiDayHearingConfirmationNotificationTests.cs
@@ -22,6 +22,8 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var expectedNotificationType = NotificationType.HearingConfirmationJudgeMultiDay;
             var participant = InitParticipant("Judge");
             var hearing = InitHearing();
+            var expectedConferencePhoneNumber = "07703123123";
+            
             hearing.OtherInformation = JsonConvert.SerializeObject(new OtherInformationDetails
                 {JudgeEmail = "judge@hmcts.net", JudgePhone = "123456789"});
 
@@ -33,10 +35,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"Start Day Month Year", "12 October 2020"},
                 {"judge", participant.DisplayName},
                 {"courtroom account username", participant.Username},
-                {"number of days", "4"}
+                {"number of days", "4"},
+                {"conference phone number", expectedConferencePhoneNumber }
             };
             
-            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4);
+            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -55,6 +58,8 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var participant = InitParticipant("Individual");
             var hearing = InitHearing();
 
+            var expectedConferencePhoneNumber = "07703123123";
+            
             var expectedParameters = new Dictionary<string, string>
             {
                 {"case name", CaseName},
@@ -62,10 +67,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"time", "2:10 PM"},
                 {"Start Day Month Year", "12 October 2020"},
                 {"name", $"{participant.FirstName} {participant.LastName}"},
-                {"number of days", "4"}
+                {"number of days", "4"},
+                {"conference phone number", expectedConferencePhoneNumber }
             };
             
-            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4);
+            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -84,6 +90,8 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var participant = InitParticipant("Representative", "Jane Doe");
             var hearing = InitHearing();
 
+            var expectedConferencePhoneNumber = "07703123123";
+            
             var expectedParameters = new Dictionary<string, string>
             {
                 {"case name", CaseName},
@@ -92,10 +100,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"Start Day Month Year", "12 October 2020"},
                 {"solicitor name", $"{participant.FirstName} {participant.LastName}"},
                 {"client name", $"{participant.Representee}"},
-                {"number of days", "4"}
+                {"number of days", "4"},
+                {"conference phone number", expectedConferencePhoneNumber }
             };
             
-            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4);
+            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -113,7 +122,8 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var expectedNotificationType = NotificationType.HearingConfirmationJohMultiDay;
             var participant = InitParticipant("Judicial Office Holder");
             var hearing = InitHearing();
-
+            var expectedConferencePhoneNumber = "07703123123";
+            
             var expectedParameters = new Dictionary<string, string>
             {
                 {"case name", CaseName},
@@ -121,10 +131,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"time", "2:10 PM"},
                 {"Start Day Month Year", "12 October 2020"},
                 {"judicial office holder", $"{participant.FirstName} {participant.LastName}"},
-                {"number of days", "4"}
+                {"number of days", "4"},
+                {"conference phone number", expectedConferencePhoneNumber }
             };
             
-            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4);
+            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToMultiDayHearingConfirmationNotificationTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/NotificationMappers/MapToMultiDayHearingConfirmationNotificationTests.cs
@@ -23,6 +23,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var participant = InitParticipant("Judge");
             var hearing = InitHearing();
             var expectedConferencePhoneNumber = "07703123123";
+            var expectedConferenceId = "id";
             
             hearing.OtherInformation = JsonConvert.SerializeObject(new OtherInformationDetails
                 {JudgeEmail = "judge@hmcts.net", JudgePhone = "123456789"});
@@ -36,10 +37,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"judge", participant.DisplayName},
                 {"courtroom account username", participant.Username},
                 {"number of days", "4"},
-                {"conference phone number", expectedConferencePhoneNumber }
+                {"conference phone number", expectedConferencePhoneNumber },
+                {"conference phone id", expectedConferenceId}
             };
             
-            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber);
+            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber, expectedConferenceId);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -59,6 +61,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var hearing = InitHearing();
 
             var expectedConferencePhoneNumber = "07703123123";
+            var expectedConferenceId = "id";
             
             var expectedParameters = new Dictionary<string, string>
             {
@@ -68,10 +71,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"Start Day Month Year", "12 October 2020"},
                 {"name", $"{participant.FirstName} {participant.LastName}"},
                 {"number of days", "4"},
-                {"conference phone number", expectedConferencePhoneNumber }
+                {"conference phone number", expectedConferencePhoneNumber },
+                {"conference phone id", expectedConferenceId}
             };
             
-            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber);
+            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber, expectedConferenceId);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -91,6 +95,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var hearing = InitHearing();
 
             var expectedConferencePhoneNumber = "07703123123";
+            var expectedConferenceId = "id";
             
             var expectedParameters = new Dictionary<string, string>
             {
@@ -101,10 +106,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"solicitor name", $"{participant.FirstName} {participant.LastName}"},
                 {"client name", $"{participant.Representee}"},
                 {"number of days", "4"},
-                {"conference phone number", expectedConferencePhoneNumber }
+                {"conference phone number", expectedConferencePhoneNumber },
+                {"conference phone id", expectedConferenceId }
             };
             
-            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber);
+            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber, expectedConferenceId);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);
@@ -123,6 +129,7 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
             var participant = InitParticipant("Judicial Office Holder");
             var hearing = InitHearing();
             var expectedConferencePhoneNumber = "07703123123";
+            var expectedConferenceId = "id";
             
             var expectedParameters = new Dictionary<string, string>
             {
@@ -132,10 +139,11 @@ namespace AdminWebsite.UnitTests.Mappers.NotificationMappers
                 {"Start Day Month Year", "12 October 2020"},
                 {"judicial office holder", $"{participant.FirstName} {participant.LastName}"},
                 {"number of days", "4"},
-                {"conference phone number", expectedConferencePhoneNumber }
+                {"conference phone number", expectedConferencePhoneNumber },
+                {"conference phone id", expectedConferenceId }
             };
             
-            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber);
+            var result = AddNotificationRequestMapper.MapToMultiDayHearingConfirmationNotification(hearing, participant, 4, expectedConferencePhoneNumber, expectedConferenceId);
             
             result.Should().NotBeNull();
             result.HearingId.Should().Be(hearing.Id);

--- a/AdminWebsite/AdminWebsite.UnitTests/Services/ConferencesServiceTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Services/ConferencesServiceTests.cs
@@ -15,13 +15,13 @@ namespace AdminWebsite.UnitTests.Services
     public class ConferencesServiceTests
     {
         private AutoMock _mocker;
-        private IConferencesService _serviceUnderTest;
+        private IConferenceDetailsService _serviceUnderTest;
         
         [SetUp]
         public void SetUp()
         {
             _mocker = AutoMock.GetLoose();
-            _serviceUnderTest = _mocker.Create<ConferencesService>();
+            _serviceUnderTest = _mocker.Create<ConferenceDetailsService>();
         }
 
         [Test]

--- a/AdminWebsite/AdminWebsite.UnitTests/Services/ConferencesServiceTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Services/ConferencesServiceTests.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Threading.Tasks;
+using AdminWebsite.Configuration;
+using AdminWebsite.Services;
+using Autofac.Extras.Moq;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using VideoApi.Client;
+using VideoApi.Contract.Responses;
+
+namespace AdminWebsite.UnitTests.Services
+{
+    public class ConferencesServiceTests
+    {
+        private AutoMock _mocker;
+        private IConferencesService _serviceUnderTest;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            _mocker = AutoMock.GetLoose();
+            _serviceUnderTest = _mocker.Create<ConferencesService>();
+        }
+
+        [Test]
+        public async Task Should_call_polly_wait_retry_and_return_expected_response()
+        {
+            Guid hearingId = Guid.NewGuid();
+            var expectedConferenceDetailsResponse = new ConferenceDetailsResponse
+            {
+                Id = Guid.NewGuid(),
+                HearingId = hearingId,
+                MeetingRoom = new MeetingRoomResponse
+                {
+                    JudgeUri = "judge",
+                    ParticipantUri = "participant",
+                    PexipNode = "pexip"
+                }
+            };
+            
+            _mocker.Mock<IPollyRetryService>().Setup(x => x.WaitAndRetryAsync<VideoApiException, ConferenceDetailsResponse>
+            (
+            It.IsAny<int>(), It.IsAny<Func<int, TimeSpan>>(), It.IsAny<Action<int>>(),
+            It.IsAny<Func<ConferenceDetailsResponse, bool>>(), It.IsAny<Func<Task<ConferenceDetailsResponse>>>()
+            ))
+            .Callback(async (int retries, Func<int, TimeSpan> sleepDuration, Action<int> retryAction,
+                Func<ConferenceDetailsResponse, bool> handleResultCondition, Func<Task<ConferenceDetailsResponse>> executeFunction) =>
+            {
+                sleepDuration(1);
+                retryAction(1);
+                handleResultCondition(expectedConferenceDetailsResponse);
+                await executeFunction();
+            })
+            .ReturnsAsync(expectedConferenceDetailsResponse);
+
+            var response = await _serviceUnderTest.GetConferenceDetailsByHearingIdWithRetry(hearingId, "error message");
+            
+            _mocker.Mock<IPollyRetryService>().Verify(x => x.WaitAndRetryAsync<VideoApiException, ConferenceDetailsResponse>
+               (
+                   It.IsAny<int>(), It.IsAny<Func<int, TimeSpan>>(), It.IsAny<Action<int>>(),
+                   It.IsAny<Func<ConferenceDetailsResponse, bool>>(), It.IsAny<Func<Task<ConferenceDetailsResponse>>>()
+               ), Times.AtLeastOnce);
+
+            response.Should().Be(expectedConferenceDetailsResponse);
+        }
+        
+        [Test]
+        public async Task Should_return_an_empty_respons_if_an_exception_is_thrown()
+        {
+            Guid hearingId = Guid.NewGuid();
+            var expectedConferenceDetailsResponse = new ConferenceDetailsResponse();
+            
+            _mocker.Mock<IPollyRetryService>().Setup(x => x.WaitAndRetryAsync<VideoApiException, ConferenceDetailsResponse>
+            (
+            It.IsAny<int>(), It.IsAny<Func<int, TimeSpan>>(), It.IsAny<Action<int>>(),
+            It.IsAny<Func<ConferenceDetailsResponse, bool>>(), It.IsAny<Func<Task<ConferenceDetailsResponse>>>()
+            ))
+            .Callback(async (int retries, Func<int, TimeSpan> sleepDuration, Action<int> retryAction,
+                Func<ConferenceDetailsResponse, bool> handleResultCondition, Func<Task<ConferenceDetailsResponse>> executeFunction) =>
+            {
+                sleepDuration(1);
+                retryAction(7);
+                handleResultCondition(expectedConferenceDetailsResponse);
+                await executeFunction();
+            })
+            .ThrowsAsync(new VideoApiException("", 400, "", null, null));
+
+            var response = await _serviceUnderTest.GetConferenceDetailsByHearingIdWithRetry(hearingId, "error message");
+            
+            _mocker.Mock<IPollyRetryService>().Verify(x => x.WaitAndRetryAsync<VideoApiException, ConferenceDetailsResponse>
+               (
+                   It.IsAny<int>(), It.IsAny<Func<int, TimeSpan>>(), It.IsAny<Action<int>>(),
+                   It.IsAny<Func<ConferenceDetailsResponse, bool>>(), It.IsAny<Func<Task<ConferenceDetailsResponse>>>()
+               ), Times.AtLeastOnce);
+
+            response.Should().BeEquivalentTo(expectedConferenceDetailsResponse);
+        }
+        
+        [Test]
+        public async Task Should_return_response_from_video_api_client()
+        {
+            Guid hearingId = Guid.NewGuid();
+            var expectedConferenceDetailsResponse = new ConferenceDetailsResponse();
+
+            _mocker.Mock<IVideoApiClient>()
+                .Setup(x => x.GetConferenceByHearingRefIdAsync(hearingId, false))
+                .ReturnsAsync(expectedConferenceDetailsResponse);
+            
+            var response = await _serviceUnderTest.GetConferenceDetailsByHearingId(hearingId);
+            
+            _mocker.Mock<IVideoApiClient>().Verify(x => x.GetConferenceByHearingRefIdAsync(hearingId, false), Times.Once);
+
+            response.Should().BeEquivalentTo(expectedConferenceDetailsResponse);
+        }
+    }
+}

--- a/AdminWebsite/AdminWebsite.UnitTests/Services/HearingServiceTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Services/HearingServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AdminWebsite.Configuration;
 using AdminWebsite.Extensions;
 using AdminWebsite.Models;
 using AdminWebsite.Services;
@@ -9,12 +10,15 @@ using Autofac.Extras.Moq;
 using BookingsApi.Client;
 using BookingsApi.Contract.Responses;
 using FizzWare.NBuilder;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using NotificationApi.Client;
 using NotificationApi.Contract;
 using NotificationApi.Contract.Requests;
 using NUnit.Framework;
+using VideoApi.Contract.Responses;
 using CaseResponse = BookingsApi.Contract.Responses.CaseResponse;
 
 namespace AdminWebsite.UnitTests.Services
@@ -24,35 +28,61 @@ namespace AdminWebsite.UnitTests.Services
         private AutoMock _mocker;
         private HearingsService _service;
         private HearingDetailsResponse _hearing;
-
+        private const string _expectedTeleConferencePhoneNumber = "expected_conference_phone_number";
+        
         [SetUp]
         public void Setup()
         {
             _mocker = AutoMock.GetLoose();
+            _mocker.Mock<IOptions<KinlyConfiguration>>().Setup(opt => opt.Value).Returns(new KinlyConfiguration()
+            {
+                ConferencePhoneNumber = _expectedTeleConferencePhoneNumber
+            });
             _service = _mocker.Create<HearingsService>();
             _hearing = InitHearing();
         }
 
         [Test]
+        public async Task should_return_correct_tele_conference_id_and_phone_number()
+        {
+            // Arrange
+            var expectedTeleConferenceId = "tele_conference_id";
+            var service = new Mock<IHearingsService>();
+            service.Setup(s => s.GetTelephoneConferenceDetails(It.IsAny<Guid>())).CallBase();
+            service.Setup(s => s.GetConferenceDetailsByHearingIdWithRetry(It.IsAny<Guid>(), It.IsAny<string>())).ReturnsAsync(
+                new ConferenceDetailsResponse
+                {
+                    MeetingRoom = new MeetingRoomResponse()
+                    {
+                        TelephoneConferenceId = expectedTeleConferenceId
+                    }
+                });
+            
+            // Act
+            var teleConferenceDetails = await service.Object.GetTelephoneConferenceDetails(Guid.NewGuid());
+            
+            // Assert
+            teleConferenceDetails.TeleConferencePhoneNumber.Should().Be(_expectedTeleConferencePhoneNumber);
+            teleConferenceDetails.TeleConferenceId.Should().Be(expectedTeleConferenceId);
+        }
+        
+        [Test]
         public async Task should_send_confirmation_email_to_all_participants_except_judge()
         {
-            var expectedConferencePhoneNumber = "phone_number";
             var judge = _hearing.Participants.First(x => x.UserRoleName == "Judge");
-            await _service.SendHearingConfirmationEmail(_hearing, expectedConferencePhoneNumber);
+            await _service.SendHearingConfirmationEmail(_hearing);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
-                    x => x.CreateNewNotificationAsync(It.Is<AddNotificationRequest>(r => r.ParticipantId != judge.Id &&
-                        r.Parameters["conference phone number"] == expectedConferencePhoneNumber)),
+                    x => x.CreateNewNotificationAsync(It.Is<AddNotificationRequest>(r => r.ParticipantId != judge.Id)),
                     Times.Exactly(3));
         }
 
         [Test]
         public async Task should_not_send_confirmation_email_when_hearing_is_generic_case_type()
         {
-            var expectedConferencePhoneNumber = "phone_number";
             _hearing.CaseTypeName = "Generic";
-            await _service.SendHearingConfirmationEmail(_hearing, expectedConferencePhoneNumber);
+            await _service.SendHearingConfirmationEmail(_hearing);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
@@ -68,7 +98,7 @@ namespace AdminWebsite.UnitTests.Services
 
             var secondHearing = InitHearing();
             secondHearing.ScheduledDateTime = _hearing.ScheduledDateTime.AddDays(1).AddHours(3).AddMinutes(20);
-            await _service.SendHearingUpdateEmail(_hearing, secondHearing, "phone_number");
+            await _service.SendHearingUpdateEmail(_hearing, secondHearing);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
@@ -79,18 +109,17 @@ namespace AdminWebsite.UnitTests.Services
         [Test]
         public async Task should_send_amendment_email_to_all_participants()
         {
-            var expectedConferencePhoneNumber = "phone_number";
             var secondHearing = InitHearing();
             _hearing.GroupId = secondHearing.GroupId = _hearing.Id;
 
             secondHearing.OtherInformation =
                 new OtherInformationDetails {JudgeEmail = "judge@hmcts.net"}.ToOtherInformationString();
             secondHearing.ScheduledDateTime = _hearing.ScheduledDateTime.AddDays(1).AddHours(3).AddMinutes(20);
-            await _service.SendHearingUpdateEmail(_hearing, secondHearing, "phone_number");
+            await _service.SendHearingUpdateEmail(_hearing, secondHearing);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
-                    x => x.CreateNewNotificationAsync(It.Is<AddNotificationRequest>(r => r.Parameters["conference phone number"] == expectedConferencePhoneNumber)),
+                    x => x.CreateNewNotificationAsync(It.IsAny<AddNotificationRequest>()),
                     Times.Exactly(secondHearing.Participants.Count));
         }
         
@@ -99,16 +128,15 @@ namespace AdminWebsite.UnitTests.Services
         {
             var secondHearing = InitHearing();
             _hearing.GroupId = secondHearing.GroupId = _hearing.Id;
-            var expectedConferencePhoneNumber = "phone_number";
 
             secondHearing.OtherInformation =
                 new OtherInformationDetails {JudgeEmail = "judge@hmcts.net"}.ToOtherInformationString();
             secondHearing.ScheduledDateTime = _hearing.ScheduledDateTime.AddDays(1).AddHours(3).AddMinutes(20);
-            await _service.SendHearingUpdateEmail(secondHearing, secondHearing, "phone_number");
+            await _service.SendHearingUpdateEmail(secondHearing, secondHearing);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
-                    x => x.CreateNewNotificationAsync(It.Is<AddNotificationRequest>(r => r.Parameters["conference phone number"] == expectedConferencePhoneNumber)),
+                    x => x.CreateNewNotificationAsync(It.IsAny<AddNotificationRequest>()),
                     Times.Exactly(secondHearing.Participants.Count -1));
             
             _mocker.Mock<INotificationApiClient>()
@@ -152,14 +180,13 @@ namespace AdminWebsite.UnitTests.Services
         [Test]
         public async Task should_send_multiday_confirmation_email_to_all_participants_except_judge()
         {
-            var expectedConferencePhoneNumber = "phone_number";
             var judge = _hearing.Participants.First(x => x.UserRoleName == "Judge");
             
-            await _service.SendMultiDayHearingConfirmationEmail(_hearing, 2, expectedConferencePhoneNumber);
+            await _service.SendMultiDayHearingConfirmationEmail(_hearing, 2);
             
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
-                    x => x.CreateNewNotificationAsync(It.Is<AddNotificationRequest>(r => r.ParticipantId != judge.Id && r.Parameters["conference phone number"] == expectedConferencePhoneNumber)),
+                    x => x.CreateNewNotificationAsync(It.Is<AddNotificationRequest>(r => r.ParticipantId != judge.Id)),
                     Times.Exactly(_hearing.Participants.Count(x => x.UserRoleName.ToLower() != "judge")));
         }
         
@@ -170,7 +197,7 @@ namespace AdminWebsite.UnitTests.Services
             _hearing.CaseTypeName = "Generic";
             secondHearing.CaseTypeName = "Generic";
             secondHearing.ScheduledDateTime = _hearing.ScheduledDateTime.AddDays(1).AddHours(3).AddMinutes(20);
-            await _service.SendHearingUpdateEmail(_hearing, secondHearing, "phone_number");
+            await _service.SendHearingUpdateEmail(_hearing, secondHearing);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
@@ -181,13 +208,12 @@ namespace AdminWebsite.UnitTests.Services
         [Test]
         public async Task should_send_reminder_email_to_all_participants_except_a_judge()
         {
-            var expectedConferencePhoneNumber = "phone_number";
             var judge = _hearing.Participants.First(x => x.UserRoleName == "Judge");
-            await _service.SendHearingReminderEmail(_hearing, "phone_number");
+            await _service.SendHearingReminderEmail(_hearing);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
-                    x => x.CreateNewNotificationAsync(It.Is<AddNotificationRequest>(r => r.ParticipantId != judge.Id && r.Parameters["conference phone number"] == expectedConferencePhoneNumber)),
+                    x => x.CreateNewNotificationAsync(It.Is<AddNotificationRequest>(r => r.ParticipantId != judge.Id)),
                     Times.Exactly(3));
         }
         
@@ -197,7 +223,7 @@ namespace AdminWebsite.UnitTests.Services
             var judge = _hearing.Participants.First(x => x.UserRoleName == "Judge");
             _hearing.OtherInformation = new OtherInformationDetails {JudgeEmail = "judge@hmcts.net"}.ToOtherInformationString();
             _mocker.Mock<IBookingsApiClient>().Setup(x => x.GetHearingsByGroupIdAsync(_hearing.GroupId.Value)).ReturnsAsync(new List<HearingDetailsResponse> {_hearing});
-            await _service.SendHearingReminderEmail(_hearing, "phone_number");
+            await _service.SendHearingReminderEmail(_hearing);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
@@ -209,7 +235,6 @@ namespace AdminWebsite.UnitTests.Services
         [Test]
         public async Task should_send_confirmation_email_to_judge_when_reminder_is_sent_to_participants_for_multi_day_hearing()
         {
-            var expectedConferencePhoneNumber = "phone_number";
             var judge = _hearing.Participants.First(x => x.UserRoleName == "Judge");
             _hearing.OtherInformation = new OtherInformationDetails {JudgeEmail = "judge@hmcts.net"}.ToOtherInformationString();
             var hearing2 = InitHearing();
@@ -224,7 +249,7 @@ namespace AdminWebsite.UnitTests.Services
             _mocker.Mock<IBookingsApiClient>().Setup(x => x.GetHearingsByGroupIdAsync(_hearing.GroupId.Value))
                 .ReturnsAsync(listOfHearings);
 
-            await _service.SendHearingReminderEmail(_hearing, expectedConferencePhoneNumber);
+            await _service.SendHearingReminderEmail(_hearing);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
@@ -236,7 +261,6 @@ namespace AdminWebsite.UnitTests.Services
         [Test]
         public async Task should_not_send_confirmation_email_to_judge_when_reminder_is_sent_to_participants_for_multi_day_hearing_and_is_not_the_main_hearing()
         {
-            var expectedConferencePhoneNumber = "phone_number";
             var judge = _hearing.Participants.First(x => x.UserRoleName == "Judge");
             _hearing.OtherInformation = new OtherInformationDetails {JudgeEmail = "judge@hmcts.net"}.ToOtherInformationString();
             var hearing2 = InitHearing();
@@ -251,13 +275,13 @@ namespace AdminWebsite.UnitTests.Services
             _mocker.Mock<IBookingsApiClient>().Setup(x => x.GetHearingsByGroupIdAsync(_hearing.GroupId.Value))
                 .ReturnsAsync(listOfHearings);
 
-            await _service.SendHearingReminderEmail(hearing2, "phone_number");
+            await _service.SendHearingReminderEmail(hearing2);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
                     x => x.CreateNewNotificationAsync(It.Is<AddNotificationRequest>(
                         r => r.ParticipantId == judge.Id && 
-                             r.NotificationType == NotificationType.HearingConfirmationJudgeMultiDay && r.Parameters["conference phone number"] == expectedConferencePhoneNumber)),
+                             r.NotificationType == NotificationType.HearingConfirmationJudgeMultiDay)),
                     Times.Never);
         }
         
@@ -267,7 +291,7 @@ namespace AdminWebsite.UnitTests.Services
             var judge = _hearing.Participants.First(x => x.UserRoleName == "Judge");
             _hearing.OtherInformation = new OtherInformationDetails {JudgeEmail = null}.ToOtherInformationString();
             _mocker.Mock<IBookingsApiClient>().Setup(x => x.GetHearingsByGroupIdAsync(_hearing.GroupId.Value)).ReturnsAsync(new List<HearingDetailsResponse> {_hearing});
-            await _service.SendHearingReminderEmail(_hearing, "phone_number");
+            await _service.SendHearingReminderEmail(_hearing);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(
@@ -281,7 +305,7 @@ namespace AdminWebsite.UnitTests.Services
             var expectedConferencePhoneNumber = "phone_number";
             var judge = _hearing.Participants.First(x => x.UserRoleName == "Judge");
             _hearing.CaseTypeName = "Generic";
-            await _service.SendHearingReminderEmail(_hearing, "phone_number");
+            await _service.SendHearingReminderEmail(_hearing);
 
             _mocker.Mock<INotificationApiClient>()
                 .Verify(

--- a/AdminWebsite/AdminWebsite.UnitTests/Services/HearingServiceTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Services/HearingServiceTests.cs
@@ -40,7 +40,7 @@ namespace AdminWebsite.UnitTests.Services
                 ConferencePhoneNumber = _expectedTeleConferencePhoneNumber
             });
 
-            _mocker.Mock<IConferencesService>()
+            _mocker.Mock<IConferenceDetailsService>()
                 .Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
                 .ReturnsAsync(new ConferenceDetailsResponse
                 {

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -38,7 +38,7 @@ namespace AdminWebsite.Controllers
         private readonly IBookingsApiClient _bookingsApiClient;
         private readonly IValidator<EditHearingRequest> _editHearingRequestValidator;
         private readonly IHearingsService _hearingsService;
-        private readonly IConferencesService _conferencesService;
+        private readonly IConferenceDetailsService _conferenceDetailsService;
         private readonly ILogger<HearingsController> _logger;
         private readonly IUserAccountService _userAccountService;
         private readonly IUserIdentity _userIdentity;
@@ -49,7 +49,7 @@ namespace AdminWebsite.Controllers
         /// </summary>
         public HearingsController(IBookingsApiClient bookingsApiClient, IUserIdentity userIdentity,
             IUserAccountService userAccountService, IValidator<EditHearingRequest> editHearingRequestValidator,
-            ILogger<HearingsController> logger, IHearingsService hearingsService, IConferencesService conferencesService, IPublicHolidayRetriever publicHolidayRetriever)
+            ILogger<HearingsController> logger, IHearingsService hearingsService, IConferenceDetailsService conferenceDetailsService, IPublicHolidayRetriever publicHolidayRetriever)
         {
             _bookingsApiClient = bookingsApiClient;
             _userIdentity = userIdentity;
@@ -57,7 +57,7 @@ namespace AdminWebsite.Controllers
             _editHearingRequestValidator = editHearingRequestValidator;
             _logger = logger;
             _hearingsService = hearingsService;
-            _conferencesService = conferencesService;
+            _conferenceDetailsService = conferenceDetailsService;
             _publicHolidayRetriever = publicHolidayRetriever;
         }
 
@@ -411,7 +411,7 @@ namespace AdminWebsite.Controllers
                 {
                     _logger.LogDebug("Hearing {Hearing} is confirmed. Polling for Conference in VideoApi", hearingId);
                     var conferenceDetailsResponse =
-                        await _conferencesService.GetConferenceDetailsByHearingIdWithRetry(hearingId, errorMessage);
+                        await _conferenceDetailsService.GetConferenceDetailsByHearingIdWithRetry(hearingId, errorMessage);
                     _logger.LogInformation("Found conference for hearing {Hearing}", hearingId);
                     if (conferenceDetailsResponse.HasValidMeetingRoom()) 
                     {
@@ -469,7 +469,7 @@ namespace AdminWebsite.Controllers
         {
             try
             {
-                var conferenceDetailsResponse = await _conferencesService.GetConferenceDetailsByHearingId(hearingId);
+                var conferenceDetailsResponse = await _conferenceDetailsService.GetConferenceDetailsByHearingId(hearingId);
 
                 if (conferenceDetailsResponse.HasValidMeetingRoom())
                     return Ok(new PhoneConferenceResponse

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -38,6 +38,7 @@ namespace AdminWebsite.Controllers
         private readonly IBookingsApiClient _bookingsApiClient;
         private readonly IValidator<EditHearingRequest> _editHearingRequestValidator;
         private readonly IHearingsService _hearingsService;
+        private readonly IConferencesService _conferencesService;
         private readonly ILogger<HearingsController> _logger;
         private readonly IUserAccountService _userAccountService;
         private readonly IUserIdentity _userIdentity;
@@ -48,7 +49,7 @@ namespace AdminWebsite.Controllers
         /// </summary>
         public HearingsController(IBookingsApiClient bookingsApiClient, IUserIdentity userIdentity,
             IUserAccountService userAccountService, IValidator<EditHearingRequest> editHearingRequestValidator,
-            ILogger<HearingsController> logger, IHearingsService hearingsService, IPublicHolidayRetriever publicHolidayRetriever)
+            ILogger<HearingsController> logger, IHearingsService hearingsService, IConferencesService conferencesService, IPublicHolidayRetriever publicHolidayRetriever)
         {
             _bookingsApiClient = bookingsApiClient;
             _userIdentity = userIdentity;
@@ -56,6 +57,7 @@ namespace AdminWebsite.Controllers
             _editHearingRequestValidator = editHearingRequestValidator;
             _logger = logger;
             _hearingsService = hearingsService;
+            _conferencesService = conferencesService;
             _publicHolidayRetriever = publicHolidayRetriever;
         }
 
@@ -409,7 +411,7 @@ namespace AdminWebsite.Controllers
                 {
                     _logger.LogDebug("Hearing {Hearing} is confirmed. Polling for Conference in VideoApi", hearingId);
                     var conferenceDetailsResponse =
-                        await _hearingsService.GetConferenceDetailsByHearingIdWithRetry(hearingId, errorMessage);
+                        await _conferencesService.GetConferenceDetailsByHearingIdWithRetry(hearingId, errorMessage);
                     _logger.LogInformation("Found conference for hearing {Hearing}", hearingId);
                     if (conferenceDetailsResponse.HasValidMeetingRoom()) 
                     {
@@ -467,7 +469,7 @@ namespace AdminWebsite.Controllers
         {
             try
             {
-                var conferenceDetailsResponse = await _hearingsService.GetConferenceDetailsByHearingId(hearingId);
+                var conferenceDetailsResponse = await _conferencesService.GetConferenceDetailsByHearingId(hearingId);
 
                 if (conferenceDetailsResponse.HasValidMeetingRoom())
                     return Ok(new PhoneConferenceResponse

--- a/AdminWebsite/AdminWebsite/Extensions/ConfigureServicesExtensions.cs
+++ b/AdminWebsite/AdminWebsite/Extensions/ConfigureServicesExtensions.cs
@@ -78,6 +78,7 @@ namespace AdminWebsite.Extensions
             serviceCollection.AddTransient<VideoApiTokenHandler>();
             serviceCollection.AddTransient<NotificationApiTokenHandler>();
             serviceCollection.AddTransient<IHearingsService, HearingsService>();
+            serviceCollection.AddTransient<IConferenceDetailsService, ConferenceDetailsService>();
             serviceCollection.AddScoped<ITokenProvider, TokenProvider>();
             serviceCollection.AddScoped<IUserAccountService, UserAccountService>();
             serviceCollection.AddScoped<AzureAdConfiguration>();

--- a/AdminWebsite/AdminWebsite/Mappers/AddNotificationRequestMapper.cs
+++ b/AdminWebsite/AdminWebsite/Mappers/AddNotificationRequestMapper.cs
@@ -57,7 +57,7 @@ namespace AdminWebsite.Mappers
 
         public static AddNotificationRequest MapToHearingAmendmentNotification(HearingDetailsResponse hearing,
             ParticipantResponse participant, string caseName, string caseNumber, DateTime originalDateTime,
-            DateTime newDateTime)
+            DateTime newDateTime, string conferencePhoneNumber)
         {
             var parameters = new Dictionary<string, string>
             {
@@ -95,6 +95,9 @@ namespace AdminWebsite.Mappers
                 notificationType = NotificationType.HearingAmendmentLip;
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
+            
+            parameters.Add("conference phone number", $"{conferencePhoneNumber}");
+
 
             return new AddNotificationRequest
             {
@@ -109,7 +112,7 @@ namespace AdminWebsite.Mappers
         }
 
         public static AddNotificationRequest MapToHearingConfirmationNotification(HearingDetailsResponse hearing,
-            ParticipantResponse participant)
+            ParticipantResponse participant, string conferencePhoneNumber)
         {
             var parameters = InitConfirmReminderParams(hearing);
 
@@ -140,6 +143,8 @@ namespace AdminWebsite.Mappers
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
 
+            parameters.Add("conference phone number", $"{conferencePhoneNumber}");
+            
             return new AddNotificationRequest
             {
                 HearingId = hearing.Id,
@@ -154,7 +159,7 @@ namespace AdminWebsite.Mappers
 
         public static AddNotificationRequest MapToMultiDayHearingConfirmationNotification(
             HearingDetailsResponse hearing,
-            ParticipantResponse participant, int days)
+            ParticipantResponse participant, int days, string conferencePhoneNumber)
         {
             var @case = hearing.Cases.First();
             var cleanedCaseName = @case.Name.Replace($"Day 1 of {days}", string.Empty).Trim();
@@ -192,6 +197,8 @@ namespace AdminWebsite.Mappers
                 notificationType = NotificationType.HearingConfirmationLipMultiDay;
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
+            
+            parameters.Add("conference phone number", $"{conferencePhoneNumber}");
 
             return new AddNotificationRequest
             {
@@ -206,7 +213,7 @@ namespace AdminWebsite.Mappers
         }
 
         public static AddNotificationRequest MapToHearingReminderNotification(HearingDetailsResponse hearing,
-            ParticipantResponse participant)
+            ParticipantResponse participant, string conferencePhoneNumber)
         {
             var parameters = InitConfirmReminderParams(hearing);
             parameters.Add("username", participant.Username.ToLower());
@@ -229,6 +236,8 @@ namespace AdminWebsite.Mappers
                 notificationType = NotificationType.HearingReminderLip;
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
+            
+            parameters.Add("conference phone number", $"{conferencePhoneNumber}");
 
             return new AddNotificationRequest
             {

--- a/AdminWebsite/AdminWebsite/Mappers/AddNotificationRequestMapper.cs
+++ b/AdminWebsite/AdminWebsite/Mappers/AddNotificationRequestMapper.cs
@@ -103,8 +103,11 @@ namespace AdminWebsite.Mappers
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
             
-            parameters.Add("conference phone number", $"{conferencePhoneNumber}");
-            parameters.Add("conference phone id", $"{conferencePhoneId}");
+            if (!string.IsNullOrWhiteSpace(conferencePhoneNumber) && !string.IsNullOrWhiteSpace(conferencePhoneId))
+            {
+                parameters.Add("conference phone number", $"{conferencePhoneNumber}");
+                parameters.Add("conference phone id", $"{conferencePhoneId}");
+            }
 
 
             return new AddNotificationRequest
@@ -158,9 +161,12 @@ namespace AdminWebsite.Mappers
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
 
-            parameters.Add("conference phone number", $"{conferencePhoneNumber}");
-            parameters.Add("conference phone id", $"{conferencePhoneId}");
-            
+            if (!string.IsNullOrWhiteSpace(conferencePhoneNumber) && !string.IsNullOrWhiteSpace(conferencePhoneId))
+            {
+                parameters.Add("conference phone number", $"{conferencePhoneNumber}");
+                parameters.Add("conference phone id", $"{conferencePhoneId}");
+            }
+
             return new AddNotificationRequest
             {
                 HearingId = hearing.Id,
@@ -221,8 +227,11 @@ namespace AdminWebsite.Mappers
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
             
-            parameters.Add("conference phone number", $"{conferencePhoneNumber}");
-            parameters.Add("conference phone id", $"{conferencePhoneId}");
+            if (!string.IsNullOrWhiteSpace(conferencePhoneNumber) && !string.IsNullOrWhiteSpace(conferencePhoneId))
+            {
+                parameters.Add("conference phone number", $"{conferencePhoneNumber}");
+                parameters.Add("conference phone id", $"{conferencePhoneId}");
+            }
 
             return new AddNotificationRequest
             {
@@ -261,8 +270,11 @@ namespace AdminWebsite.Mappers
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
             
-            parameters.Add("conference phone number", $"{conferencePhoneNumber}");
-            parameters.Add("conference phone id", $"{conferencePhoneId}");
+            if (!string.IsNullOrWhiteSpace(conferencePhoneNumber) && !string.IsNullOrWhiteSpace(conferencePhoneId))
+            {
+                parameters.Add("conference phone number", $"{conferencePhoneNumber}");
+                parameters.Add("conference phone id", $"{conferencePhoneId}");
+            }
 
             return new AddNotificationRequest
             {

--- a/AdminWebsite/AdminWebsite/Mappers/AddNotificationRequestMapper.cs
+++ b/AdminWebsite/AdminWebsite/Mappers/AddNotificationRequestMapper.cs
@@ -102,24 +102,9 @@ namespace AdminWebsite.Mappers
                 notificationType = NotificationType.HearingAmendmentLip;
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
-            
-            if (!string.IsNullOrWhiteSpace(conferencePhoneNumber) && !string.IsNullOrWhiteSpace(conferencePhoneId))
-            {
-                parameters.Add("conference phone number", $"{conferencePhoneNumber}");
-                parameters.Add("conference phone id", $"{conferencePhoneId}");
-            }
 
-
-            return new AddNotificationRequest
-            {
-                HearingId = hearing.Id,
-                MessageType = MessageType.Email,
-                ContactEmail = participant.ContactEmail,
-                NotificationType = notificationType,
-                ParticipantId = participant.Id,
-                PhoneNumber = participant.TelephoneNumber,
-                Parameters = parameters
-            };
+            return CreateNotificationRequest(hearing.Id, MessageType.Email, participant.ContactEmail, notificationType,
+                participant.Id, participant.TelephoneNumber, parameters, conferencePhoneNumber, conferencePhoneId);
         }
 
         public static AddNotificationRequest MapToHearingConfirmationNotification(HearingDetailsResponse hearing,
@@ -161,22 +146,8 @@ namespace AdminWebsite.Mappers
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
 
-            if (!string.IsNullOrWhiteSpace(conferencePhoneNumber) && !string.IsNullOrWhiteSpace(conferencePhoneId))
-            {
-                parameters.Add("conference phone number", $"{conferencePhoneNumber}");
-                parameters.Add("conference phone id", $"{conferencePhoneId}");
-            }
-
-            return new AddNotificationRequest
-            {
-                HearingId = hearing.Id,
-                MessageType = MessageType.Email,
-                ContactEmail = participant.ContactEmail,
-                NotificationType = notificationType,
-                ParticipantId = participant.Id,
-                PhoneNumber = participant.TelephoneNumber,
-                Parameters = parameters
-            };
+            return CreateNotificationRequest(hearing.Id, MessageType.Email, participant.ContactEmail, notificationType,
+                participant.Id, participant.TelephoneNumber, parameters, conferencePhoneNumber, conferencePhoneId);
         }
 
         public static AddNotificationRequest MapToMultiDayHearingConfirmationNotification(
@@ -226,23 +197,9 @@ namespace AdminWebsite.Mappers
                 notificationType = NotificationType.HearingConfirmationLipMultiDay;
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
-            
-            if (!string.IsNullOrWhiteSpace(conferencePhoneNumber) && !string.IsNullOrWhiteSpace(conferencePhoneId))
-            {
-                parameters.Add("conference phone number", $"{conferencePhoneNumber}");
-                parameters.Add("conference phone id", $"{conferencePhoneId}");
-            }
 
-            return new AddNotificationRequest
-            {
-                HearingId = hearing.Id,
-                MessageType = MessageType.Email,
-                ContactEmail = participant.ContactEmail,
-                NotificationType = notificationType,
-                ParticipantId = participant.Id,
-                PhoneNumber = participant.TelephoneNumber,
-                Parameters = parameters
-            };
+            return CreateNotificationRequest(hearing.Id, MessageType.Email, participant.ContactEmail, notificationType,
+                participant.Id, participant.TelephoneNumber, parameters, conferencePhoneNumber, conferencePhoneId);
         }
 
         public static AddNotificationRequest MapToHearingReminderNotification(HearingDetailsResponse hearing,
@@ -269,7 +226,13 @@ namespace AdminWebsite.Mappers
                 notificationType = NotificationType.HearingReminderLip;
                 parameters.Add("name", $"{participant.FirstName} {participant.LastName}");
             }
-            
+
+            return CreateNotificationRequest(hearing.Id, MessageType.Email, participant.ContactEmail, notificationType,
+                participant.Id, participant.TelephoneNumber, parameters, conferencePhoneNumber, conferencePhoneId);
+        }
+
+        private static AddNotificationRequest CreateNotificationRequest(Guid hearingId, MessageType messageType, string participantContactEmail, NotificationType notificationType, Guid participantId, string participantTelephoneNumber, Dictionary<string, string> parameters, string conferencePhoneNumber, string conferencePhoneId)
+        {
             if (!string.IsNullOrWhiteSpace(conferencePhoneNumber) && !string.IsNullOrWhiteSpace(conferencePhoneId))
             {
                 parameters.Add("conference phone number", $"{conferencePhoneNumber}");
@@ -278,12 +241,12 @@ namespace AdminWebsite.Mappers
 
             return new AddNotificationRequest
             {
-                HearingId = hearing.Id,
-                MessageType = MessageType.Email,
-                ContactEmail = participant.ContactEmail,
+                HearingId = hearingId,
+                MessageType = messageType,
+                ContactEmail = participantContactEmail,
                 NotificationType = notificationType,
-                ParticipantId = participant.Id,
-                PhoneNumber = participant.TelephoneNumber,
+                ParticipantId = participantId,
+                PhoneNumber = participantTelephoneNumber,
                 Parameters = parameters
             };
         }

--- a/AdminWebsite/AdminWebsite/Mappers/AddNotificationRequestMapper.cs
+++ b/AdminWebsite/AdminWebsite/Mappers/AddNotificationRequestMapper.cs
@@ -57,7 +57,7 @@ namespace AdminWebsite.Mappers
 
         public static AddNotificationRequest MapToHearingAmendmentNotification(HearingDetailsResponse hearing,
             ParticipantResponse participant, string caseName, string caseNumber, DateTime originalDateTime,
-            DateTime newDateTime, string conferencePhoneNumber)
+            DateTime newDateTime, string conferencePhoneNumber, string conferencePhoneId)
         {
             var parameters = new Dictionary<string, string>
             {
@@ -97,6 +97,7 @@ namespace AdminWebsite.Mappers
             }
             
             parameters.Add("conference phone number", $"{conferencePhoneNumber}");
+            parameters.Add("conference phone id", $"{conferencePhoneId}");
 
 
             return new AddNotificationRequest
@@ -112,7 +113,7 @@ namespace AdminWebsite.Mappers
         }
 
         public static AddNotificationRequest MapToHearingConfirmationNotification(HearingDetailsResponse hearing,
-            ParticipantResponse participant, string conferencePhoneNumber)
+            ParticipantResponse participant, string conferencePhoneNumber, string conferencePhoneId)
         {
             var parameters = InitConfirmReminderParams(hearing);
 
@@ -144,6 +145,7 @@ namespace AdminWebsite.Mappers
             }
 
             parameters.Add("conference phone number", $"{conferencePhoneNumber}");
+            parameters.Add("conference phone id", $"{conferencePhoneId}");
             
             return new AddNotificationRequest
             {
@@ -159,7 +161,7 @@ namespace AdminWebsite.Mappers
 
         public static AddNotificationRequest MapToMultiDayHearingConfirmationNotification(
             HearingDetailsResponse hearing,
-            ParticipantResponse participant, int days, string conferencePhoneNumber)
+            ParticipantResponse participant, int days, string conferencePhoneNumber, string conferencePhoneId)
         {
             var @case = hearing.Cases.First();
             var cleanedCaseName = @case.Name.Replace($"Day 1 of {days}", string.Empty).Trim();
@@ -199,6 +201,7 @@ namespace AdminWebsite.Mappers
             }
             
             parameters.Add("conference phone number", $"{conferencePhoneNumber}");
+            parameters.Add("conference phone id", $"{conferencePhoneId}");
 
             return new AddNotificationRequest
             {
@@ -213,7 +216,7 @@ namespace AdminWebsite.Mappers
         }
 
         public static AddNotificationRequest MapToHearingReminderNotification(HearingDetailsResponse hearing,
-            ParticipantResponse participant, string conferencePhoneNumber)
+            ParticipantResponse participant, string conferencePhoneNumber, string conferencePhoneId)
         {
             var parameters = InitConfirmReminderParams(hearing);
             parameters.Add("username", participant.Username.ToLower());
@@ -238,6 +241,7 @@ namespace AdminWebsite.Mappers
             }
             
             parameters.Add("conference phone number", $"{conferencePhoneNumber}");
+            parameters.Add("conference phone id", $"{conferencePhoneId}");
 
             return new AddNotificationRequest
             {

--- a/AdminWebsite/AdminWebsite/Services/ConferenceDetailsService.cs
+++ b/AdminWebsite/AdminWebsite/Services/ConferenceDetailsService.cs
@@ -11,20 +11,20 @@ using VideoApi.Contract.Responses;
 
 namespace AdminWebsite.Services
 {
-    public interface IConferencesService
+    public interface IConferenceDetailsService
     {
         Task<ConferenceDetailsResponse> GetConferenceDetailsByHearingIdWithRetry(Guid hearingId, string errorMessage);
 
         Task<ConferenceDetailsResponse> GetConferenceDetailsByHearingId(Guid hearingId);
     }
     
-    public class ConferencesService : IConferencesService
+    public class ConferenceDetailsService : IConferenceDetailsService
     {
         private readonly IPollyRetryService _pollyRetryService;
-        private readonly ILogger<ConferencesService> _logger;
+        private readonly ILogger<ConferenceDetailsService> _logger;
         private readonly IVideoApiClient _videoApiClient;
 
-        public ConferencesService(IPollyRetryService pollyRetryService, ILogger<ConferencesService> logger, IVideoApiClient videoApiClient)
+        public ConferenceDetailsService(IPollyRetryService pollyRetryService, ILogger<ConferenceDetailsService> logger, IVideoApiClient videoApiClient)
         {
             _pollyRetryService = pollyRetryService;
             _logger = logger;

--- a/AdminWebsite/AdminWebsite/Services/ConferencesService.cs
+++ b/AdminWebsite/AdminWebsite/Services/ConferencesService.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AdminWebsite.Configuration;
+using AdminWebsite.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using VideoApi.Client;
+using VideoApi.Contract.Responses;
+
+namespace AdminWebsite.Services
+{
+    public interface IConferencesService
+    {
+        Task<ConferenceDetailsResponse> GetConferenceDetailsByHearingIdWithRetry(Guid hearingId, string errorMessage);
+
+        Task<ConferenceDetailsResponse> GetConferenceDetailsByHearingId(Guid hearingId);
+    }
+    
+    public class ConferencesService : IConferencesService
+    {
+        private readonly IPollyRetryService _pollyRetryService;
+        private readonly ILogger<ConferencesService> _logger;
+        private readonly IVideoApiClient _videoApiClient;
+
+        public ConferencesService(IPollyRetryService pollyRetryService, ILogger<ConferencesService> logger, IVideoApiClient videoApiClient)
+        {
+            _pollyRetryService = pollyRetryService;
+            _logger = logger;
+            _videoApiClient = videoApiClient;
+        }
+
+        public async Task<ConferenceDetailsResponse> GetConferenceDetailsByHearingIdWithRetry(Guid hearingId, string errorMessage)
+        {
+            try
+            {
+                var details = await _pollyRetryService.WaitAndRetryAsync<VideoApiException, ConferenceDetailsResponse>
+                (
+                    6, _ => TimeSpan.FromSeconds(8),
+                    retryAttempt =>
+                        _logger.LogWarning(
+                            "Failed to retrieve conference details from the VideoAPi for hearingId {Hearing}. Retrying attempt {RetryAttempt}", hearingId, retryAttempt),
+                    videoApiResponseObject => !videoApiResponseObject.HasValidMeetingRoom(),
+                    () => _videoApiClient.GetConferenceByHearingRefIdAsync(hearingId, false)
+                );
+                return details;
+            }
+            catch (VideoApiException ex)
+            {
+                _logger.LogError(ex, $"{errorMessage}: {ex.Message}");
+            }
+            
+            return new ConferenceDetailsResponse();
+        }
+
+        public async Task<ConferenceDetailsResponse> GetConferenceDetailsByHearingId(Guid hearingId)
+        {
+            return await _videoApiClient.GetConferenceByHearingRefIdAsync(hearingId, false);
+        }
+    }
+}

--- a/AdminWebsite/AdminWebsite/Services/HearingsService.cs
+++ b/AdminWebsite/AdminWebsite/Services/HearingsService.cs
@@ -84,18 +84,18 @@ namespace AdminWebsite.Services
         private readonly INotificationApiClient _notificationApiClient;
         private readonly IBookingsApiClient _bookingsApiClient;
         private readonly ILogger<HearingsService> _logger;
-        private readonly IConferencesService _conferencesService;
+        private readonly IConferenceDetailsService _conferenceDetailsService;
         private readonly KinlyConfiguration _kinlyConfiguration;
 
         public HearingsService(IPollyRetryService pollyRetryService, IUserAccountService userAccountService,
-            INotificationApiClient notificationApiClient, IBookingsApiClient bookingsApiClient, ILogger<HearingsService> logger, IConferencesService conferencesService, IOptions<KinlyConfiguration> kinlyOptions)
+            INotificationApiClient notificationApiClient, IBookingsApiClient bookingsApiClient, ILogger<HearingsService> logger, IConferenceDetailsService conferenceDetailsService, IOptions<KinlyConfiguration> kinlyOptions)
         {
             _pollyRetryService = pollyRetryService;
             _userAccountService = userAccountService;
             _notificationApiClient = notificationApiClient;
             _bookingsApiClient = bookingsApiClient;
             _logger = logger;
-            _conferencesService = conferencesService;
+            _conferenceDetailsService = conferenceDetailsService;
             _kinlyConfiguration = kinlyOptions.Value;
         }
 
@@ -279,7 +279,7 @@ namespace AdminWebsite.Services
 
         public async Task<TeleConferenceDetails> GetTelephoneConferenceDetails(Guid hearingId)
         {
-            var conferenceDetailsResponse = await _conferencesService.GetConferenceDetailsByHearingId(hearingId);
+            var conferenceDetailsResponse = await _conferenceDetailsService.GetConferenceDetailsByHearingId(hearingId);
             if (conferenceDetailsResponse.HasValidMeetingRoom())
                 return new TeleConferenceDetails(_kinlyConfiguration.ConferencePhoneNumber,
                     conferenceDetailsResponse.MeetingRoom.TelephoneConferenceId);

--- a/AdminWebsite/AdminWebsite/Services/HearingsService.cs
+++ b/AdminWebsite/AdminWebsite/Services/HearingsService.cs
@@ -22,18 +22,6 @@ using UpdateParticipantRequest = BookingsApi.Contract.Requests.UpdateParticipant
 
 namespace AdminWebsite.Services
 {
-    public class TeleConferenceDetails
-    {
-        public string TeleConferencePhoneNumber { get; }
-        public string TeleConferenceId { get; }
-
-        public TeleConferenceDetails(string teleConferencePhoneNumber, string teleConferenceId)
-        {
-            TeleConferencePhoneNumber = teleConferencePhoneNumber;
-            TeleConferenceId = teleConferenceId;
-        }
-    }
-    
     public interface IHearingsService
     {
         Task AssignParticipantToCorrectGroups(HearingDetailsResponse hearing,

--- a/AdminWebsite/AdminWebsite/Services/Models/TeleConferenceDetails.cs
+++ b/AdminWebsite/AdminWebsite/Services/Models/TeleConferenceDetails.cs
@@ -1,0 +1,14 @@
+﻿namespace AdminWebsite.Services.Models
+{
+    public class TeleConferenceDetails
+    {
+        public string TeleConferencePhoneNumber { get; }
+        public string TeleConferenceId { get; }
+
+        public TeleConferenceDetails(string teleConferencePhoneNumber, string teleConferenceId)
+        {
+            TeleConferencePhoneNumber = teleConferencePhoneNumber;
+            TeleConferenceId = teleConferenceId;
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-7571

### Change description ###
- Moved conference details methods from HearingsService to a new service (ConferenceDetailsService)
- Added a method to HearingsService to get the telephone conference details
- Added conference id and conference phone number to the parameters for relevant gov notify emails
- Modified and updated tests to work with the changes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
