### PR TITLE
Feature/vih 7886 use ejudiciary accounts for panel members and wingers

### DIFF
--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
@@ -257,7 +257,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         }
 
         [Test]
-        public async Task Should_update_user_details_for_panel_member()
+        public async Task Should_not_update_user_details_for_panel_member()
         {
             var participant = new BookingsApi.Contract.Requests.ParticipantRequest
             {
@@ -275,11 +275,11 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             await PostWithParticipants(participant);
 
             _mocker.Mock<IUserAccountService>().Verify(x => x.UpdateParticipantUsername(participant), Times.Never);
-            _mocker.Mock<IUserAccountService>().Verify(x => x.GetAdUserIdForUsername(participant.Username), Times.Once);            
+            _mocker.Mock<IUserAccountService>().Verify(x => x.GetAdUserIdForUsername(participant.Username), Times.Never);            
         }
 
         [Test]
-        public async Task Should_update_user_details_for_winger()
+        public async Task Should_not_update_user_details_for_winger()
         {
             var participant = new BookingsApi.Contract.Requests.ParticipantRequest
             {
@@ -297,7 +297,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             await PostWithParticipants(participant);
 
             _mocker.Mock<IUserAccountService>().Verify(x => x.UpdateParticipantUsername(participant), Times.Never);
-            _mocker.Mock<IUserAccountService>().Verify(x => x.GetAdUserIdForUsername(participant.Username), Times.Once);
+            _mocker.Mock<IUserAccountService>().Verify(x => x.GetAdUserIdForUsername(participant.Username), Times.Never);
         }
 
         [Test]

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.spec.ts
@@ -758,16 +758,16 @@ describe('AddParticipantComponent', () => {
             const testCases = [
                 { searchJudiciaryEntriesValue: null, role: '', expectError: false },
                 { searchJudiciaryEntriesValue: null, role: 'Other', expectError: false },
-                { searchJudiciaryEntriesValue: null, role: 'Panel Member', expectError: false },
-                { searchJudiciaryEntriesValue: null, role: 'Winger', expectError: false },
+                { searchJudiciaryEntriesValue: null, role: 'Panel Member', expectError: true },
+                { searchJudiciaryEntriesValue: null, role: 'Winger', expectError: true },
                 { searchJudiciaryEntriesValue: emptyPersonResponse, role: '', expectError: false },
                 { searchJudiciaryEntriesValue: emptyPersonResponse, role: 'Other', expectError: false },
-                { searchJudiciaryEntriesValue: emptyPersonResponse, role: 'Panel Member', expectError: false },
+                { searchJudiciaryEntriesValue: emptyPersonResponse, role: 'Panel Member', expectError: true },
                 { searchJudiciaryEntriesValue: emptyPersonResponse, role: 'Winger', expectError: false },
                 { searchJudiciaryEntriesValue: populatedPersonResponse, role: '', expectError: true },
                 { searchJudiciaryEntriesValue: populatedPersonResponse, role: 'Other', expectError: true },
-                { searchJudiciaryEntriesValue: populatedPersonResponse, role: 'Panel Member', expectError: true },
-                { searchJudiciaryEntriesValue: populatedPersonResponse, role: 'Winger', expectError: true }
+                { searchJudiciaryEntriesValue: populatedPersonResponse, role: 'Panel Member', expectError: false },
+                { searchJudiciaryEntriesValue: populatedPersonResponse, role: 'Winger', expectError: false }
             ];
 
             beforeEach(

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.spec.ts
@@ -763,7 +763,7 @@ describe('AddParticipantComponent', () => {
                 { searchJudiciaryEntriesValue: emptyPersonResponse, role: '', expectError: false },
                 { searchJudiciaryEntriesValue: emptyPersonResponse, role: 'Other', expectError: false },
                 { searchJudiciaryEntriesValue: emptyPersonResponse, role: 'Panel Member', expectError: true },
-                { searchJudiciaryEntriesValue: emptyPersonResponse, role: 'Winger', expectError: false },
+                { searchJudiciaryEntriesValue: emptyPersonResponse, role: 'Winger', expectError: true },
                 { searchJudiciaryEntriesValue: populatedPersonResponse, role: '', expectError: true },
                 { searchJudiciaryEntriesValue: populatedPersonResponse, role: 'Other', expectError: true },
                 { searchJudiciaryEntriesValue: populatedPersonResponse, role: 'Panel Member', expectError: false },

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
@@ -44,5 +44,5 @@ export const Constants = {
     DefenceAdvocate: 'App Advocate',
     None: 'None',
     RespondentAdvocate: 'Respondent Advocate',
-    JudiciaryRoles: []
+    JudiciaryRoles: ['Panel Member', 'Winger']
 };

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.spec.ts
@@ -157,26 +157,17 @@ describe('SearchService', () => {
             service.participantSearch(terms, roleJudiciary).subscribe(participants => {
                 expect(participants.length).toEqual(participantList.length);
             });
-            expect(service.searchEntries).toHaveBeenCalledWith(terms);
-            expect(service.searchEntries).toHaveBeenCalledTimes(1);
 
-            expect(service.searchJudiciaryEntries).toHaveBeenCalledTimes(0);
+            expect(service.searchJudiciaryEntries).toHaveBeenCalledWith(terms);
+            expect(service.searchJudiciaryEntries).toHaveBeenCalledTimes(1);
+
+            expect(service.searchEntries).toHaveBeenCalledTimes(0);
             expect(service.searchJudgeAccounts).toHaveBeenCalledTimes(0);
 
-            expect(ParticipantModel.fromPersonResponse).toHaveBeenCalledTimes(personList.length);
-            personList.forEach(person => {
+            expect(ParticipantModel.fromPersonResponse).toHaveBeenCalledTimes(judiciaryPersonList.length);
+            judiciaryPersonList.forEach(person => {
                 expect(ParticipantModel.fromPersonResponse).toHaveBeenCalledWith(person);
             });
-            // expect(service.searchJudiciaryEntries).toHaveBeenCalledWith(terms);
-            // expect(service.searchJudiciaryEntries).toHaveBeenCalledTimes(1);
-
-            // expect(service.searchEntries).toHaveBeenCalledTimes(0);
-            // expect(service.searchJudgeAccounts).toHaveBeenCalledTimes(0);
-
-            // expect(ParticipantModel.fromPersonResponse).toHaveBeenCalledTimes(judiciaryPersonList.length);
-            // judiciaryPersonList.forEach(person => {
-            //     expect(ParticipantModel.fromPersonResponse).toHaveBeenCalledWith(person);
-            // });
         });
 
         it('should call searchJudgeAccounts and map response when role is judge ', () => {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.ts
@@ -75,8 +75,7 @@ export class SearchService {
         } else {
             let persons$: Observable<Array<PersonResponse>>;
             if (this.judiciaryRoles.includes(role)) {
-                // persons$ = this.searchJudiciaryEntries(term);
-                persons$ = this.searchEntries(term);
+                persons$ = this.searchJudiciaryEntries(term);
             } else {
                 persons$ = this.searchEntries(term);
             }

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -82,7 +82,8 @@ namespace AdminWebsite.Controllers
             try
             {
                 var nonJudgeParticipants = newBookingRequest.Participants.Where(p =>
-                        p.CaseRoleName != "Judge")
+                        p.CaseRoleName != "Judge" && p.HearingRoleName != "Panel Member" &&
+                        p.HearingRoleName != "Winger")
                     .ToList();
                 await PopulateUserIdsAndUsernames(nonJudgeParticipants, usernameAdIdDict);
                 if (newBookingRequest.Endpoints != null && newBookingRequest.Endpoints.Any())


### PR DESCRIPTION
### JIRA link (if applicable) ###
VIH-7886


### Change description ###
Reverting changes to only allow selection of ejudiciary accounts for panel members and wingers


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
