### PR TITLE
VIH-8629 Should not send the remainder emails up on confirmation

### DIFF
--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
@@ -141,7 +141,6 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _mocker.Mock<IConferenceDetailsService>()
                 .Setup(x => x.GetConferenceDetailsByHearingIdWithRetry(It.IsAny<Guid>(), It.IsAny<string>()))
                 .ReturnsAsync(expectedConferenceDetailsResponse);
-            _mocker.Mock<IBookingsApiClient>().Setup(x => x.GetHearingsByGroupIdAsync(hearing.GroupId.Value)).ReturnsAsync(new List<HearingDetailsResponse> { hearing });
 
             var response = await _controller.UpdateBookingStatus(hearingId, request);
 
@@ -151,9 +150,6 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             result.Value.Should().NotBeNull().And.BeAssignableTo<UpdateBookingStatusResponse>().Subject.TelephoneConferenceId.Should().Be("121212");
 
             _mocker.Mock<IBookingsApiClient>().Verify(x => x.UpdateBookingStatusAsync(hearingId, request), Times.Once);
-
-            _mocker.Mock<IHearingsService>().Verify(
-                x => x.SendHearingReminderEmail(It.Is<HearingDetailsResponse>(x => x == hearing)), Times.AtLeast(1));
         }
 
         [Test]

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -508,9 +508,6 @@ namespace AdminWebsite.Controllers
 
                     if (conferenceDetailsResponse.HasValidMeetingRoom())
                     {
-                        var hearing = await _bookingsApiClient.GetHearingDetailsByIdAsync(hearingId);
-                        _logger.LogInformation("Sending a reminder email for hearing {Hearing}", hearingId);
-                        await _hearingsService.SendHearingReminderEmail(hearing);
                         return Ok(new UpdateBookingStatusResponse
                         {
                             Success = true,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-8629

### Change description ###

- Stopped sending Remainder emails up on confirmation

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
