### PR TITLE
VIH-8784 Refactor ordering of participants in admin web

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.spec.ts
@@ -176,60 +176,182 @@ describe('ParticipantListComponent-SortParticipants', () => {
         });
     });
 
-    it('should produce a sorted list with specific hierarchy and grouping', () => {
-        const participantsArr = [
-            { is_judge: true,  case_role_name:null, hearing_role_name: 'Judge', first_name: 'L' },
-            { is_judge: false, case_role_name:'Winger', hearing_role_name: 'None', first_name: 'K' },
-            { is_judge: false, case_role_name:'None', hearing_role_name: 'Winger', first_name: 'J' },
-            { is_judge: false, case_role_name:null, hearing_role_name: 'Staff Member', first_name: 'I' },
-            { is_judge: false, case_role_name:'None', hearing_role_name: 'Panel Member', first_name: 'H' },
-            { is_judge: false, case_role_name:'None', hearing_role_name: 'Observer', first_name: 'G' },
-            { is_judge: false, case_role_name:'Appellant', hearing_role_name: 'Litigant in Person', first_name: 'F' },
-            { is_judge: false, case_role_name:'None', hearing_role_name: 'Litigant in Person', first_name: 'E' },
-            { is_judge: false, case_role_name:'Appellant', hearing_role_name: 'Litigant in Person', first_name: 'D' },
-            { is_judge: false, case_role_name:'Appellant', email:'interpretees@email.co.uk', hearing_role_name: 'Litigant in Person', first_name: 'C' },
-            { is_judge: false, case_role_name:'None', hearing_role_name: 'Litigant in Person', first_name: 'B' },
-            { is_judge: false, case_role_name:'Appellant', hearing_role_name: 'Litigant in Person', first_name: 'A' },
-            { is_judge: false, case_role_name:'None', hearing_role_name: 'Interpreter', first_name: 'A', interpreterFor: 'interpretees@email.co.uk'},
-            { is_judge: false, case_role_name:'Observer', hearing_role_name: 'new observer type', first_name: 'M' }
-        ];
+    it('should produce a sorted list with specific hierarchy and grouping',
+        () => {
+            const participantsArr = [
+                {is_judge: true, case_role_name: null, hearing_role_name: 'Judge', first_name: 'L'},
+                {is_judge: false, case_role_name: 'Winger', hearing_role_name: 'None', first_name: 'K'},
+                {is_judge: false, case_role_name: 'None', hearing_role_name: 'Winger', first_name: 'J'},
+                {is_judge: false, case_role_name: null, hearing_role_name: 'Staff Member', first_name: 'I'},
+                {is_judge: false, case_role_name: 'None', hearing_role_name: 'Panel Member', first_name: 'H'},
+                {is_judge: false, case_role_name: 'None', hearing_role_name: 'Observer', first_name: 'G'},
+                {
+                    is_judge: false,
+                    case_role_name: 'Appellant',
+                    hearing_role_name: 'Litigant in Person',
+                    first_name: 'F'
+                },
+                {is_judge: false, case_role_name: 'None', hearing_role_name: 'Litigant in Person', first_name: 'E'},
+                {
+                    is_judge: false,
+                    case_role_name: 'Appellant',
+                    hearing_role_name: 'Litigant in Person',
+                    first_name: 'D'
+                },
+                {
+                    is_judge: false, case_role_name: 'Appellant', email: 'interpretees@email.co.uk',
+                    hearing_role_name: 'Litigant in Person', first_name: 'C'
+                },
+                {is_judge: false, case_role_name: 'None', hearing_role_name: 'Litigant in Person', first_name: 'B'},
+                {
+                    is_judge: false,
+                    case_role_name: 'Appellant',
+                    hearing_role_name: 'Litigant in Person',
+                    first_name: 'A'
+                },
+                {
+                    is_judge: false, case_role_name: 'None', hearing_role_name: 'Interpreter', first_name: 'A',
+                    interpreterFor: 'interpretees@email.co.uk'
+                },
+                {is_judge: false, case_role_name: 'Observer', hearing_role_name: 'new observer type', first_name: 'M'}
+            ];
 
-        if (!component.hearing.participants) {
-            component.hearing.participants = [];
-        }
-        participantsArr.forEach((p, i) => {
-            component.hearing.participants.push({
-                is_judge: p.is_judge,
-                hearing_role_name: p.hearing_role_name,
-                first_name: p.first_name,
-                case_role_name: p.case_role_name,
-                email: p.email,
-                interpreterFor: p.interpreterFor
+            if (!component.hearing.participants) {
+                component.hearing.participants = [];
+            }
+            participantsArr.forEach((p, i) => {
+                component.hearing.participants.push({
+                    is_judge: p.is_judge,
+                    hearing_role_name: p.hearing_role_name,
+                    first_name: p.first_name,
+                    case_role_name: p.case_role_name,
+                    email: p.email,
+                    interpreterFor: p.interpreterFor
+                });
             });
+
+            component.ngOnInit();
+
+            const expectedResult: ParticipantModel[] = [];
+            expectedResult.push({
+                is_judge: true,
+                case_role_name: null,
+                email: undefined,
+                hearing_role_name: 'Judge',
+                first_name: 'L',
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'None',
+                email: undefined,
+                hearing_role_name: 'Panel Member',
+                first_name: 'H',
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'None',
+                email: undefined,
+                hearing_role_name: 'Winger',
+                first_name: 'J',
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'Winger',
+                email: undefined,
+                hearing_role_name: 'None',
+                first_name: 'K',
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: null,
+                email: undefined,
+                hearing_role_name: 'Staff Member',
+                first_name: 'I',
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'Appellant',
+                email: undefined,
+                hearing_role_name: 'Litigant in Person',
+                first_name: 'A',
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'Appellant',
+                email: 'interpretees@email.co.uk',
+                hearing_role_name: 'Litigant in Person',
+                first_name: 'C',
+                is_interpretee: true,
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'None',
+                email: undefined,
+                hearing_role_name: 'Interpreter',
+                first_name: 'A',
+                interpreterFor: 'interpretees@email.co.uk',
+                interpretee_name: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'Appellant',
+                email: undefined,
+                hearing_role_name: 'Litigant in Person',
+                first_name: 'D',
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'Appellant',
+                email: undefined,
+                hearing_role_name: 'Litigant in Person',
+                first_name: 'F',
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'None',
+                email: undefined,
+                hearing_role_name: 'Litigant in Person',
+                first_name: 'B',
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'None',
+                email: undefined,
+                hearing_role_name: 'Litigant in Person',
+                first_name: 'E',
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'None',
+                email: undefined,
+                hearing_role_name: 'Observer',
+                first_name: 'G',
+                interpreterFor: undefined
+            });
+            expectedResult.push({
+                is_judge: false,
+                case_role_name: 'Observer',
+                email: undefined,
+                hearing_role_name: 'new observer type',
+                first_name: 'M',
+                interpreterFor: undefined
+            });
+
+            for (let i = 0; i < expectedResult.length; i++) {
+                expect(component.sortedParticipants[i]).toEqual(expectedResult[i]);
+            }
         });
-
-        component.ngOnInit();
-
-        const expectedResult: ParticipantModel[] = [];
-        expectedResult.push({ is_judge: true,  case_role_name: null, email:undefined, hearing_role_name: 'Judge', first_name: 'L', interpreterFor: undefined });
-        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Panel Member', first_name: 'H', interpreterFor: undefined});
-        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Winger', first_name: 'J', interpreterFor: undefined });
-        expectedResult.push({ is_judge: false, case_role_name:'Winger', email:undefined, hearing_role_name: 'None', first_name: 'K', interpreterFor: undefined });
-        expectedResult.push({ is_judge: false, case_role_name: null, email:undefined, hearing_role_name: 'Staff Member', first_name: 'I', interpreterFor: undefined });
-        expectedResult.push({ is_judge: false, case_role_name:'Appellant', email:undefined, hearing_role_name: 'Litigant in Person', first_name: 'A', interpreterFor: undefined });
-        expectedResult.push({ is_judge: false, case_role_name:'Appellant', email:'interpretees@email.co.uk', hearing_role_name: 'Litigant in Person', first_name: 'C',  is_interpretee: true, interpreterFor: undefined});
-        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Interpreter', first_name: 'A', interpreterFor:'interpretees@email.co.uk', interpretee_name: undefined});
-        expectedResult.push({ is_judge: false, case_role_name:'Appellant', email:undefined, hearing_role_name: 'Litigant in Person', first_name: 'D', interpreterFor: undefined });
-        expectedResult.push({ is_judge: false, case_role_name:'Appellant', email:undefined, hearing_role_name: 'Litigant in Person', first_name: 'F', interpreterFor: undefined });
-        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Litigant in Person', first_name: 'B', interpreterFor: undefined });
-        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Litigant in Person', first_name: 'E', interpreterFor: undefined });
-        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Observer', first_name: 'G', interpreterFor: undefined });
-        expectedResult.push({ is_judge: false, case_role_name:'Observer', email:undefined, hearing_role_name: 'new observer type', first_name: 'M', interpreterFor: undefined });
-
-        for (let i = 0; i < expectedResult.length; i++) {
-            expect(component.sortedParticipants[i]).toEqual(expectedResult[i]);
-        }
-    });
 
     describe('ngDoCheck', () => {
         const linked_participantList: LinkedParticipantModel[] = [];
@@ -261,7 +383,8 @@ describe('ParticipantListComponent-SortParticipants', () => {
             },
             { is_judge: false, hearing_role_name: 'Litigant in Person', display_name: 'Litigant in Person2', linked_participants: null },
             { is_judge: false, hearing_role_name: 'Litigant in Person', display_name: 'Litigant in Person3', linked_participants: null },
-            { is_judge: false, hearing_role_name: 'Interpreter', display_name: 'Interpreter1', linked_participants: linked_participantList, id: '9'}
+            { is_judge: false, hearing_role_name: 'Interpreter', display_name: 'Interpreter1',
+                linked_participants: linked_participantList, id: '9'}
         ];
 
         beforeEach(() => {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.spec.ts
@@ -174,17 +174,61 @@ describe('ParticipantListComponent-SortParticipants', () => {
                 is_courtroom_account: false
             });
         });
+    });
+
+    it('should produce a sorted list with specific hierarchy and grouping', () => {
+        const participantsArr = [
+            { is_judge: true,  case_role_name:null, hearing_role_name: 'Judge', first_name: 'L' },
+            { is_judge: false, case_role_name:'Winger', hearing_role_name: 'None', first_name: 'K' },
+            { is_judge: false, case_role_name:'None', hearing_role_name: 'Winger', first_name: 'J' },
+            { is_judge: false, case_role_name:null, hearing_role_name: 'Staff Member', first_name: 'I' },
+            { is_judge: false, case_role_name:'None', hearing_role_name: 'Panel Member', first_name: 'H' },
+            { is_judge: false, case_role_name:'None', hearing_role_name: 'Observer', first_name: 'G' },
+            { is_judge: false, case_role_name:'Appellant', hearing_role_name: 'Litigant in Person', first_name: 'F' },
+            { is_judge: false, case_role_name:'None', hearing_role_name: 'Litigant in Person', first_name: 'E' },
+            { is_judge: false, case_role_name:'Appellant', hearing_role_name: 'Litigant in Person', first_name: 'D' },
+            { is_judge: false, case_role_name:'Appellant', email:'interpretees@email.co.uk', hearing_role_name: 'Litigant in Person', first_name: 'C' },
+            { is_judge: false, case_role_name:'None', hearing_role_name: 'Litigant in Person', first_name: 'B' },
+            { is_judge: false, case_role_name:'Appellant', hearing_role_name: 'Litigant in Person', first_name: 'A' },
+            { is_judge: false, case_role_name:'None', hearing_role_name: 'Interpreter', first_name: 'A', interpreterFor: 'interpretees@email.co.uk'},
+            { is_judge: false, case_role_name:'Observer', hearing_role_name: 'new observer type', first_name: 'M' }
+        ];
+
+        if (!component.hearing.participants) {
+            component.hearing.participants = [];
+        }
+        participantsArr.forEach((p, i) => {
+            component.hearing.participants.push({
+                is_judge: p.is_judge,
+                hearing_role_name: p.hearing_role_name,
+                first_name: p.first_name,
+                case_role_name: p.case_role_name,
+                email: p.email,
+                interpreterFor: p.interpreterFor
+            });
+        });
 
         component.ngOnInit();
 
-        expect(component.sortedParticipants.length).toBe(11);
-        expect(component.sortedParticipants.filter(p => p.hearing_role_name === 'Judge').length).toBe(2);
-        expect(component.sortedParticipants.filter(p => p.hearing_role_name === 'Winger').length).toBe(2);
-        expect(component.sortedParticipants.filter(p => p.hearing_role_name === 'Panel Member').length).toBe(1);
-        expect(component.sortedParticipants.filter(p => p.hearing_role_name === 'Staff Member').length).toBe(1);
-        expect(component.sortedParticipants.filter(p => p.hearing_role_name === 'Observer').length).toBe(1);
-        expect(component.sortedParticipants.filter(p => p.hearing_role_name === 'Litigant in Person').length).toBe(3);
-        expect(component.sortedParticipants.filter(p => p.hearing_role_name === 'Interpreter').length).toBe(1);
+        const expectedResult: ParticipantModel[] = [];
+        expectedResult.push({ is_judge: true,  case_role_name: null, email:undefined, hearing_role_name: 'Judge', first_name: 'L', interpreterFor: undefined });
+        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Panel Member', first_name: 'H', interpreterFor: undefined});
+        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Winger', first_name: 'J', interpreterFor: undefined });
+        expectedResult.push({ is_judge: false, case_role_name:'Winger', email:undefined, hearing_role_name: 'None', first_name: 'K', interpreterFor: undefined });
+        expectedResult.push({ is_judge: false, case_role_name: null, email:undefined, hearing_role_name: 'Staff Member', first_name: 'I', interpreterFor: undefined });
+        expectedResult.push({ is_judge: false, case_role_name:'Appellant', email:undefined, hearing_role_name: 'Litigant in Person', first_name: 'A', interpreterFor: undefined });
+        expectedResult.push({ is_judge: false, case_role_name:'Appellant', email:'interpretees@email.co.uk', hearing_role_name: 'Litigant in Person', first_name: 'C',  is_interpretee: true, interpreterFor: undefined});
+        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Interpreter', first_name: 'A', interpreterFor:'interpretees@email.co.uk', interpretee_name: undefined});
+        expectedResult.push({ is_judge: false, case_role_name:'Appellant', email:undefined, hearing_role_name: 'Litigant in Person', first_name: 'D', interpreterFor: undefined });
+        expectedResult.push({ is_judge: false, case_role_name:'Appellant', email:undefined, hearing_role_name: 'Litigant in Person', first_name: 'F', interpreterFor: undefined });
+        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Litigant in Person', first_name: 'B', interpreterFor: undefined });
+        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Litigant in Person', first_name: 'E', interpreterFor: undefined });
+        expectedResult.push({ is_judge: false, case_role_name:'None', email:undefined, hearing_role_name: 'Observer', first_name: 'G', interpreterFor: undefined });
+        expectedResult.push({ is_judge: false, case_role_name:'Observer', email:undefined, hearing_role_name: 'new observer type', first_name: 'M', interpreterFor: undefined });
+
+        for (let i = 0; i < expectedResult.length; i++) {
+            expect(component.sortedParticipants[i]).toEqual(expectedResult[i]);
+        }
     });
 
     describe('ngDoCheck', () => {
@@ -201,22 +245,23 @@ describe('ParticipantListComponent-SortParticipants', () => {
         linked_participantList1.push(linked_participant1);
 
         const participantsArr = [
-            { is_judge: true, hearing_role_name: 'Judge', display_name: 'Judge1', linked_participant: null },
-            { is_judge: true, hearing_role_name: 'Judge', display_name: 'Judge2', linked_participant: null },
-            { is_judge: false, hearing_role_name: 'Winger', display_name: 'Winger1', linked_participant: null },
-            { is_judge: false, hearing_role_name: 'Winger', display_name: 'Winger2', linked_participant: null },
-            { is_judge: false, hearing_role_name: 'Staff Member', display_name: 'Staff Member', linked_participant: null },
-            { is_judge: false, hearing_role_name: 'Panel Member', display_name: 'Panel Member', linked_participant: null },
-            { is_judge: false, hearing_role_name: 'Observer', display_name: 'Observer', linked_participant: null },
+            { is_judge: true, hearing_role_name: 'Judge', display_name: 'Judge1', linked_participants: null },
+            { is_judge: true, hearing_role_name: 'Judge', display_name: 'Judge2', linked_participants: null },
+            { is_judge: false, hearing_role_name: 'Winger', display_name: 'Winger1', linked_participants: null },
+            { is_judge: false, hearing_role_name: 'Winger', display_name: 'Winger2', linked_participants: null },
+            { is_judge: false, hearing_role_name: 'Staff Member', display_name: 'Staff Member', linked_participants: null },
+            { is_judge: false, hearing_role_name: 'Panel Member', display_name: 'Panel Member', linked_participants: null },
+            { is_judge: false, hearing_role_name: 'Observer', display_name: 'Observer', linked_participants: null },
             {
                 is_judge: false,
                 hearing_role_name: 'Litigant in Person',
                 display_name: 'Litigant in Person1',
-                linked_participant: linked_participantList1
+                linked_participants: linked_participantList1,
+                id: '7'
             },
-            { is_judge: false, hearing_role_name: 'Litigant in Person', display_name: 'Litigant in Person2', linked_participant: null },
-            { is_judge: false, hearing_role_name: 'Litigant in Person', display_name: 'Litigant in Person3', linked_participant: null },
-            { is_judge: false, hearing_role_name: 'Interpreter', display_name: 'Interpreter1', linked_participant: linked_participantList }
+            { is_judge: false, hearing_role_name: 'Litigant in Person', display_name: 'Litigant in Person2', linked_participants: null },
+            { is_judge: false, hearing_role_name: 'Litigant in Person', display_name: 'Litigant in Person3', linked_participants: null },
+            { is_judge: false, hearing_role_name: 'Interpreter', display_name: 'Interpreter1', linked_participants: linked_participantList, id: '9'}
         ];
 
         beforeEach(() => {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.spec.ts
@@ -176,182 +176,187 @@ describe('ParticipantListComponent-SortParticipants', () => {
         });
     });
 
-    it('should produce a sorted list with specific hierarchy and grouping',
-        () => {
-            const participantsArr = [
-                {is_judge: true, case_role_name: null, hearing_role_name: 'Judge', first_name: 'L'},
-                {is_judge: false, case_role_name: 'Winger', hearing_role_name: 'None', first_name: 'K'},
-                {is_judge: false, case_role_name: 'None', hearing_role_name: 'Winger', first_name: 'J'},
-                {is_judge: false, case_role_name: null, hearing_role_name: 'Staff Member', first_name: 'I'},
-                {is_judge: false, case_role_name: 'None', hearing_role_name: 'Panel Member', first_name: 'H'},
-                {is_judge: false, case_role_name: 'None', hearing_role_name: 'Observer', first_name: 'G'},
-                {
-                    is_judge: false,
-                    case_role_name: 'Appellant',
-                    hearing_role_name: 'Litigant in Person',
-                    first_name: 'F'
-                },
-                {is_judge: false, case_role_name: 'None', hearing_role_name: 'Litigant in Person', first_name: 'E'},
-                {
-                    is_judge: false,
-                    case_role_name: 'Appellant',
-                    hearing_role_name: 'Litigant in Person',
-                    first_name: 'D'
-                },
-                {
-                    is_judge: false, case_role_name: 'Appellant', email: 'interpretees@email.co.uk',
-                    hearing_role_name: 'Litigant in Person', first_name: 'C'
-                },
-                {is_judge: false, case_role_name: 'None', hearing_role_name: 'Litigant in Person', first_name: 'B'},
-                {
-                    is_judge: false,
-                    case_role_name: 'Appellant',
-                    hearing_role_name: 'Litigant in Person',
-                    first_name: 'A'
-                },
-                {
-                    is_judge: false, case_role_name: 'None', hearing_role_name: 'Interpreter', first_name: 'A',
-                    interpreterFor: 'interpretees@email.co.uk'
-                },
-                {is_judge: false, case_role_name: 'Observer', hearing_role_name: 'new observer type', first_name: 'M'}
-            ];
-
-            if (!component.hearing.participants) {
-                component.hearing.participants = [];
-            }
-            participantsArr.forEach((p, i) => {
-                component.hearing.participants.push({
-                    is_judge: p.is_judge,
-                    hearing_role_name: p.hearing_role_name,
-                    first_name: p.first_name,
-                    case_role_name: p.case_role_name,
-                    email: p.email,
-                    interpreterFor: p.interpreterFor
-                });
-            });
-
-            component.ngOnInit();
-
-            const expectedResult: ParticipantModel[] = [];
-            expectedResult.push({
-                is_judge: true,
-                case_role_name: null,
-                email: undefined,
-                hearing_role_name: 'Judge',
-                first_name: 'L',
-                interpreterFor: undefined
-            });
-            expectedResult.push({
-                is_judge: false,
-                case_role_name: 'None',
-                email: undefined,
-                hearing_role_name: 'Panel Member',
-                first_name: 'H',
-                interpreterFor: undefined
-            });
-            expectedResult.push({
-                is_judge: false,
-                case_role_name: 'None',
-                email: undefined,
-                hearing_role_name: 'Winger',
-                first_name: 'J',
-                interpreterFor: undefined
-            });
-            expectedResult.push({
-                is_judge: false,
-                case_role_name: 'Winger',
-                email: undefined,
-                hearing_role_name: 'None',
-                first_name: 'K',
-                interpreterFor: undefined
-            });
-            expectedResult.push({
-                is_judge: false,
-                case_role_name: null,
-                email: undefined,
-                hearing_role_name: 'Staff Member',
-                first_name: 'I',
-                interpreterFor: undefined
-            });
-            expectedResult.push({
+    it('should produce a sorted list with specific hierarchy and grouping', () => {
+        const participantsArr = [
+            { is_judge: true, case_role_name: null, hearing_role_name: 'Judge', first_name: 'L' },
+            { is_judge: false, case_role_name: 'Winger', hearing_role_name: 'None', first_name: 'K' },
+            { is_judge: false, case_role_name: 'None', hearing_role_name: 'Winger', first_name: 'J' },
+            { is_judge: false, case_role_name: null, hearing_role_name: 'Staff Member', first_name: 'I' },
+            { is_judge: false, case_role_name: 'None', hearing_role_name: 'Panel Member', first_name: 'H' },
+            { is_judge: false, case_role_name: 'None', hearing_role_name: 'Observer', first_name: 'G' },
+            {
                 is_judge: false,
                 case_role_name: 'Appellant',
-                email: undefined,
                 hearing_role_name: 'Litigant in Person',
-                first_name: 'A',
-                interpreterFor: undefined
-            });
-            expectedResult.push({
+                first_name: 'F'
+            },
+            { is_judge: false, case_role_name: 'None', hearing_role_name: 'Litigant in Person', first_name: 'E' },
+            {
+                is_judge: false,
+                case_role_name: 'Appellant',
+                hearing_role_name: 'Litigant in Person',
+                first_name: 'D'
+            },
+            {
                 is_judge: false,
                 case_role_name: 'Appellant',
                 email: 'interpretees@email.co.uk',
                 hearing_role_name: 'Litigant in Person',
-                first_name: 'C',
-                is_interpretee: true,
-                interpreterFor: undefined
-            });
-            expectedResult.push({
+                first_name: 'C'
+            },
+            { is_judge: false, case_role_name: 'None', hearing_role_name: 'Litigant in Person', first_name: 'B' },
+            {
+                is_judge: false,
+                case_role_name: 'Appellant',
+                hearing_role_name: 'Litigant in Person',
+                first_name: 'A'
+            },
+            {
                 is_judge: false,
                 case_role_name: 'None',
-                email: undefined,
                 hearing_role_name: 'Interpreter',
                 first_name: 'A',
-                interpreterFor: 'interpretees@email.co.uk',
-                interpretee_name: undefined
-            });
-            expectedResult.push({
-                is_judge: false,
-                case_role_name: 'Appellant',
-                email: undefined,
-                hearing_role_name: 'Litigant in Person',
-                first_name: 'D',
-                interpreterFor: undefined
-            });
-            expectedResult.push({
-                is_judge: false,
-                case_role_name: 'Appellant',
-                email: undefined,
-                hearing_role_name: 'Litigant in Person',
-                first_name: 'F',
-                interpreterFor: undefined
-            });
-            expectedResult.push({
-                is_judge: false,
-                case_role_name: 'None',
-                email: undefined,
-                hearing_role_name: 'Litigant in Person',
-                first_name: 'B',
-                interpreterFor: undefined
-            });
-            expectedResult.push({
-                is_judge: false,
-                case_role_name: 'None',
-                email: undefined,
-                hearing_role_name: 'Litigant in Person',
-                first_name: 'E',
-                interpreterFor: undefined
-            });
-            expectedResult.push({
-                is_judge: false,
-                case_role_name: 'None',
-                email: undefined,
-                hearing_role_name: 'Observer',
-                first_name: 'G',
-                interpreterFor: undefined
-            });
-            expectedResult.push({
-                is_judge: false,
-                case_role_name: 'Observer',
-                email: undefined,
-                hearing_role_name: 'new observer type',
-                first_name: 'M',
-                interpreterFor: undefined
-            });
+                interpreterFor: 'interpretees@email.co.uk'
+            },
+            { is_judge: false, case_role_name: 'Observer', hearing_role_name: 'new observer type', first_name: 'M' }
+        ];
 
-            for (let i = 0; i < expectedResult.length; i++) {
-                expect(component.sortedParticipants[i]).toEqual(expectedResult[i]);
-            }
+        if (!component.hearing.participants) {
+            component.hearing.participants = [];
+        }
+        participantsArr.forEach((p, i) => {
+            component.hearing.participants.push({
+                is_judge: p.is_judge,
+                hearing_role_name: p.hearing_role_name,
+                first_name: p.first_name,
+                case_role_name: p.case_role_name,
+                email: p.email,
+                interpreterFor: p.interpreterFor
+            });
         });
+
+        component.ngOnInit();
+
+        const expectedResult: ParticipantModel[] = [];
+        expectedResult.push({
+            is_judge: true,
+            case_role_name: null,
+            email: undefined,
+            hearing_role_name: 'Judge',
+            first_name: 'L',
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'None',
+            email: undefined,
+            hearing_role_name: 'Panel Member',
+            first_name: 'H',
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'None',
+            email: undefined,
+            hearing_role_name: 'Winger',
+            first_name: 'J',
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'Winger',
+            email: undefined,
+            hearing_role_name: 'None',
+            first_name: 'K',
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: null,
+            email: undefined,
+            hearing_role_name: 'Staff Member',
+            first_name: 'I',
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'Appellant',
+            email: undefined,
+            hearing_role_name: 'Litigant in Person',
+            first_name: 'A',
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'Appellant',
+            email: 'interpretees@email.co.uk',
+            hearing_role_name: 'Litigant in Person',
+            first_name: 'C',
+            is_interpretee: true,
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'None',
+            email: undefined,
+            hearing_role_name: 'Interpreter',
+            first_name: 'A',
+            interpreterFor: 'interpretees@email.co.uk',
+            interpretee_name: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'Appellant',
+            email: undefined,
+            hearing_role_name: 'Litigant in Person',
+            first_name: 'D',
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'Appellant',
+            email: undefined,
+            hearing_role_name: 'Litigant in Person',
+            first_name: 'F',
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'None',
+            email: undefined,
+            hearing_role_name: 'Litigant in Person',
+            first_name: 'B',
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'None',
+            email: undefined,
+            hearing_role_name: 'Litigant in Person',
+            first_name: 'E',
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'None',
+            email: undefined,
+            hearing_role_name: 'Observer',
+            first_name: 'G',
+            interpreterFor: undefined
+        });
+        expectedResult.push({
+            is_judge: false,
+            case_role_name: 'Observer',
+            email: undefined,
+            hearing_role_name: 'new observer type',
+            first_name: 'M',
+            interpreterFor: undefined
+        });
+
+        for (let i = 0; i < expectedResult.length; i++) {
+            expect(component.sortedParticipants[i]).toEqual(expectedResult[i]);
+        }
+    });
 
     describe('ngDoCheck', () => {
         const linked_participantList: LinkedParticipantModel[] = [];
@@ -383,8 +388,13 @@ describe('ParticipantListComponent-SortParticipants', () => {
             },
             { is_judge: false, hearing_role_name: 'Litigant in Person', display_name: 'Litigant in Person2', linked_participants: null },
             { is_judge: false, hearing_role_name: 'Litigant in Person', display_name: 'Litigant in Person3', linked_participants: null },
-            { is_judge: false, hearing_role_name: 'Interpreter', display_name: 'Interpreter1',
-                linked_participants: linked_participantList, id: '9'}
+            {
+                is_judge: false,
+                hearing_role_name: 'Interpreter',
+                display_name: 'Interpreter1',
+                linked_participants: linked_participantList,
+                id: '9'
+            }
         ];
 
         beforeEach(() => {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.ts
@@ -62,12 +62,13 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
 
     sortParticipants() {
         const compareByPartyThenByFirstName = () => (a, b) => {
+            const swapIndices = a > b ? 1 : 0
             const partyA = a.case_role_name === Constants.None ? a.hearing_role_name : a.case_role_name;
             const partyB = b.case_role_name === Constants.None ? b.hearing_role_name : b.case_role_name;
             if (partyA === partyB) {
-                return a.first_name < b.first_name ? -1 : a > b ? 1 : 0;
+                return a.first_name < b.first_name ? -1 : swapIndices;
             }
-            return partyA < partyB ? -1 : a > b ? 1 : 0;
+            return partyA < partyB ? -1 : swapIndices;
         };
 
         if (!this.hearing.participants) {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.ts
@@ -62,12 +62,12 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
 
     sortParticipants() {
         const compareByPartyThenByFirstName = () => (a, b) => {
-            const partyA = (a.case_role_name === Constants.None) ? a.hearing_role_name : a.case_role_name;
-            const partyB = (b.case_role_name === Constants.None) ? b.hearing_role_name : b.case_role_name;
+            const partyA = a.case_role_name === Constants.None ? a.hearing_role_name : a.case_role_name;
+            const partyB = b.case_role_name === Constants.None ? b.hearing_role_name : b.case_role_name;
             if (partyA === partyB) {
-                return (a.first_name < b.first_name) ? -1 : (a > b) ? 1 : 0;
+                return a.first_name < b.first_name ? -1 : a > b ? 1 : 0;
             }
-            return (partyA < partyB) ? -1 : (a > b) ? 1 : 0;
+            return partyA < partyB ? -1 : a > b ? 1 : 0;
         };
 
         if (!this.hearing.participants) {
@@ -75,39 +75,38 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
         }
         const judges = this.hearing.participants.filter(participant => participant.is_judge).sort(compareByPartyThenByFirstName());
 
-        const staffMembers = this.hearing.participants.filter(
-            participant => participant.hearing_role_name === Constants.HearingRoles.StaffMember
-        ).sort(compareByPartyThenByFirstName());
+        const staffMembers = this.hearing.participants
+            .filter(participant => participant.hearing_role_name === Constants.HearingRoles.StaffMember)
+            .sort(compareByPartyThenByFirstName());
 
-        const panelMembers = this.hearing.participants.filter(participant =>
-            Constants.JudiciaryRoles.includes((participant.case_role_name === Constants.None)
-                ? participant.hearing_role_name
-                : participant.case_role_name)
-        ).sort(compareByPartyThenByFirstName());
+        const panelMembers = this.hearing.participants
+            .filter(participant =>
+                Constants.JudiciaryRoles.includes(
+                    participant.case_role_name === Constants.None ? participant.hearing_role_name : participant.case_role_name
+                )
+            )
+            .sort(compareByPartyThenByFirstName());
 
-        const observers = this.hearing.participants.filter(
-            participant =>
-                Constants.HearingRoles.Observer === ((participant.case_role_name === Constants.None)
-                    ? participant.hearing_role_name
-                    : participant.case_role_name)
-        ).sort(compareByPartyThenByFirstName());
+        const observers = this.hearing.participants
+            .filter(
+                participant =>
+                    Constants.HearingRoles.Observer ===
+                    (participant.case_role_name === Constants.None ? participant.hearing_role_name : participant.case_role_name)
+            )
+            .sort(compareByPartyThenByFirstName());
 
-        const others = this.hearing.participants.filter(
-            participant =>
-                !participant.is_judge &&
-                !staffMembers.includes(participant) &&
-                !panelMembers.includes(participant) &&
-                !observers.includes(participant) &&
-                participant.hearing_role_name !== Constants.HearingRoles.Interpreter
-        ).sort(compareByPartyThenByFirstName());
+        const others = this.hearing.participants
+            .filter(
+                participant =>
+                    !participant.is_judge &&
+                    !staffMembers.includes(participant) &&
+                    !panelMembers.includes(participant) &&
+                    !observers.includes(participant) &&
+                    participant.hearing_role_name !== Constants.HearingRoles.Interpreter
+            )
+            .sort(compareByPartyThenByFirstName());
 
-        const sortedList = [
-            ...judges,
-            ...panelMembers,
-            ...staffMembers,
-            ...others,
-            ...observers
-        ];
+        const sortedList = [...judges, ...panelMembers, ...staffMembers, ...others, ...observers];
 
         this.insertInterpreters(sortedList);
         this.sortedParticipants = sortedList;
@@ -115,8 +114,9 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
 
     private insertInterpreters(sortedList: ParticipantModel[]) {
         this.clearInterpreteeList();
-        const interpreters = this.hearing.participants.filter(participant =>
-            participant.hearing_role_name === Constants.HearingRoles.Interpreter);
+        const interpreters = this.hearing.participants.filter(
+            participant => participant.hearing_role_name === Constants.HearingRoles.Interpreter
+        );
         interpreters.forEach(interpreterParticipant => {
             let interpretee: ParticipantModel;
             if (interpreterParticipant.interpreterFor) {
@@ -124,13 +124,12 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
             } else if (interpreterParticipant.linked_participants) {
                 const linkedParticipants = interpreterParticipant.linked_participants;
                 interpretee = this.hearing.participants.find(p =>
-                    linkedParticipants.some(lp => lp.linkedParticipantId === p.id &&
-                        lp.linkType === LinkedParticipantType.Interpreter)
+                    linkedParticipants.some(lp => lp.linkedParticipantId === p.id && lp.linkType === LinkedParticipantType.Interpreter)
                 );
             }
             if (interpretee) {
                 interpretee.is_interpretee = true;
-                const insertIndex: number = sortedList.findIndex((pm) => pm.email === interpretee.email) + 1;
+                const insertIndex: number = sortedList.findIndex(pm => pm.email === interpretee.email) + 1;
                 interpreterParticipant.interpretee_name = interpretee?.display_name;
                 sortedList.splice(insertIndex, 0, interpreterParticipant);
             } else {
@@ -140,7 +139,7 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
     }
 
     private clearInterpreteeList(): void {
-        this.hearing.participants.filter(participant => participant.is_interpretee).forEach(i => i.is_interpretee = false);
+        this.hearing.participants.filter(participant => participant.is_interpretee).forEach(i => (i.is_interpretee = false));
     }
 
     canEditParticipant(participant: ParticipantModel): boolean {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.ts
@@ -73,11 +73,11 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
         if (!this.hearing.participants) {
             return;
         }
-        const judges = this.hearing.participants.filter(participant => participant.is_judge);
+        const judges = this.hearing.participants.filter(participant => participant.is_judge).sort(compareByPartyThenByFirstName());
 
         const staffMembers = this.hearing.participants.filter(
             participant => participant.hearing_role_name === Constants.HearingRoles.StaffMember
-        );
+        ).sort(compareByPartyThenByFirstName());
 
         const panelMembers = this.hearing.participants.filter(participant =>
             Constants.JudiciaryRoles.includes((participant.case_role_name === Constants.None)
@@ -109,11 +109,11 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
             ...observers
         ];
 
-        this.injectInterpreters(sortedList);
+        this.insertInterpreters(sortedList);
         this.sortedParticipants = sortedList;
     }
 
-    private injectInterpreters(sortedList: ParticipantModel[]) {
+    private insertInterpreters(sortedList: ParticipantModel[]) {
         this.clearInterpreteeList();
         const interpreters = this.hearing.participants.filter(participant =>
             participant.hearing_role_name === Constants.HearingRoles.Interpreter);
@@ -134,6 +134,9 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
                 interpreterParticipant.interpretee_name = interpretee?.display_name;
                 sortedList.splice(insertIndex, 0, interpreterParticipant);
             }
+            else {
+                sortedList.push(interpreterParticipant)
+            }
         });
     }
 
@@ -141,13 +144,10 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
         this.hearing.participants.filter(participant => participant.is_interpretee).forEach(i => i.is_interpretee = false);
     }
 
-    canEditParticipant(particpant: ParticipantModel): boolean {
+    canEditParticipant(participant: ParticipantModel): boolean {
         if (!this.canEdit || this.videoHearingsService.isConferenceClosed()) {
             return false;
         }
-        if (this.videoHearingsService.isHearingAboutToStart() && !particpant.addedDuringHearing) {
-            return false;
-        }
-        return true;
+        return !(this.videoHearingsService.isHearingAboutToStart() && !participant.addedDuringHearing);
     }
 }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.ts
@@ -64,11 +64,11 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
         const compareByPartyThenByFirstName = () => (a, b) => {
             const partyA = (a.case_role_name === Constants.None) ? a.hearing_role_name : a.case_role_name;
             const partyB = (b.case_role_name === Constants.None) ? b.hearing_role_name : b.case_role_name;
-            if(partyA === partyB){
+            if (partyA === partyB) {
                 return (a.first_name < b.first_name) ? -1 : (a > b) ? 1 : 0;
             }
             return (partyA < partyB) ? -1 : (a > b) ? 1 : 0;
-        }
+        };
 
         if (!this.hearing.participants) {
             return;
@@ -126,16 +126,15 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
                 interpretee = this.hearing.participants.find(p =>
                     linkedParticipants.some(lp => lp.linkedParticipantId === p.id &&
                         lp.linkType === LinkedParticipantType.Interpreter)
-                )
+                );
             }
             if (interpretee) {
                 interpretee.is_interpretee = true;
                 const insertIndex: number = sortedList.findIndex((pm) => pm.email === interpretee.email) + 1;
                 interpreterParticipant.interpretee_name = interpretee?.display_name;
                 sortedList.splice(insertIndex, 0, interpreterParticipant);
-            }
-            else {
-                sortedList.push(interpreterParticipant)
+            } else {
+                sortedList.push(interpreterParticipant);
             }
         });
     }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/list/participant-list.component.ts
@@ -62,7 +62,7 @@ export class ParticipantListComponent implements OnInit, OnChanges, DoCheck {
 
     sortParticipants() {
         const compareByPartyThenByFirstName = () => (a, b) => {
-            const swapIndices = a > b ? 1 : 0
+            const swapIndices = a > b ? 1 : 0;
             const partyA = a.case_role_name === Constants.None ? a.hearing_role_name : a.case_role_name;
             const partyB = b.case_role_name === Constants.None ? b.hearing_role_name : b.case_role_name;
             if (partyA === partyB) {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.spec.ts
@@ -79,7 +79,8 @@ export class BookingDetailsTestData {
             'Respondent',
             '12345678',
             'interpretee',
-            false
+            false,
+            null
         );
         const p2 = new ParticipantDetailsModel(
             '2',
@@ -97,7 +98,8 @@ export class BookingDetailsTestData {
             'Respondent',
             '12345678',
             'interpretee',
-            false
+            false,
+            null
         );
         const p3 = new ParticipantDetailsModel(
             '2',
@@ -115,7 +117,8 @@ export class BookingDetailsTestData {
             'Respondent',
             '12345678',
             'interpretee',
-            false
+            false,
+            null
         );
         participants.push(p2);
         participants.push(p3);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.spec.ts
@@ -4,8 +4,8 @@ import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ParticipantDetailsModel } from '../../common/model/participant-details.model';
 import { BookingParticipantListComponent } from './booking-participant-list.component';
-import {HearingRoles} from "../../common/model/hearing-roles.model";
-import {LinkedParticipant} from "../../services/clients/api-client";
+import {HearingRoles} from '../../common/model/hearing-roles.model';
+import {LinkedParticipant} from '../../services/clients/api-client';
 
 @Component({
     selector: 'app-booking-participant-details',
@@ -114,7 +114,7 @@ describe('BookingParticipantListComponent', () => {
     });
 
     it('should produce a sorted list with specific hierarchy and grouping', done => {
-            //setup
+            // setup
             function parseTestInput(inputParticipants) {
                 const participantsArray: ParticipantDetailsModel[] = [];
                 inputParticipants.forEach((p, i) => {
@@ -125,22 +125,22 @@ describe('BookingParticipantListComponent', () => {
                         CaseRoleName: p.CaseRoleName,
                         LinkedParticipants: p.LinkedParticipants ?? null,
                         ParticipantId: `${i + 1}`,
-                        Company: "",
-                        DisplayName: "",
-                        Email: "",
+                        Company: '',
+                        DisplayName: '',
+                        Email: '',
                         Flag: false,
                         IndexInList: 0,
                         IsInterpretee: false,
                         Interpretee: p.Interpretee,
-                        LastName: "",
-                        MiddleNames: "",
-                        Phone: "",
-                        Representee: "",
-                        Title: "",
-                        UserName: "",
-                        UserRoleName: "",
+                        LastName: '',
+                        MiddleNames: '',
+                        Phone: '',
+                        Representee: '',
+                        Title: '',
+                        UserName: '',
+                        UserRoleName: '',
                         get fullName(): string {
-                            return "";
+                            return '';
                         },
                         get isInterpretee(): boolean {
                             return false;
@@ -159,9 +159,9 @@ describe('BookingParticipantListComponent', () => {
                         }
                     });
                 });
-                return participantsArray
+                return participantsArray;
             }
-            //input
+            // input
             const linked_participantList1: LinkedParticipant[] = [];
             const linked_interpretee = new LinkedParticipant();
             linked_interpretee.linked_id = '2';
@@ -173,8 +173,10 @@ describe('BookingParticipantListComponent', () => {
             linked_participantList2.push(linked_interpreter);
 
             const participantsInputArray = [
-                {CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'C', LinkedParticipants: linked_participantList1, Interpretee: 'interpretee'},
-                {CaseRoleName: 'None', HearingRoleName: 'Interpreter', FirstName: 'A', LinkedParticipants: linked_participantList2},
+                {CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'C',
+                    LinkedParticipants: linked_participantList1, Interpretee: 'interpretee'},
+                {CaseRoleName: 'None', HearingRoleName: 'Interpreter', FirstName: 'A',
+                    LinkedParticipants: linked_participantList2},
                 {isJudge: true, CaseRoleName: null, HearingRoleName: 'Judge', FirstName: 'L'},
                 {CaseRoleName: 'Winger', HearingRoleName: 'None', FirstName: 'K'},
                 {CaseRoleName: 'None', HearingRoleName: 'Winger', FirstName: 'J'},
@@ -189,23 +191,23 @@ describe('BookingParticipantListComponent', () => {
                 {CaseRoleName: 'Observer', HearingRoleName: 'new observer type', FirstName: 'M'}
             ];
             component.participants = parseTestInput(participantsInputArray);
-            //expected output
-            const expectedOutput=[
+            // expected output
+            const expectedOutput = [
                 { CaseRoleName: null, HearingRoleName: 'Judge', FirstName: 'L'},
-                { CaseRoleName:'None', HearingRoleName: 'Panel Member', FirstName: 'H'},
-                { CaseRoleName:'None', HearingRoleName: 'Winger', FirstName: 'J'},
-                { CaseRoleName:'Winger', HearingRoleName: 'None', FirstName: 'K'},
+                { CaseRoleName: 'None', HearingRoleName: 'Panel Member', FirstName: 'H'},
+                { CaseRoleName: 'None', HearingRoleName: 'Winger', FirstName: 'J'},
+                { CaseRoleName: 'Winger', HearingRoleName: 'None', FirstName: 'K'},
                 { CaseRoleName: null, HearingRoleName: 'Staff Member', FirstName: 'I'},
-                { CaseRoleName:'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'A'},
-                { CaseRoleName:'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'C'},
-                { CaseRoleName:'None', HearingRoleName: 'Interpreter', FirstName: 'A'},
-                { CaseRoleName:'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'D',},
-                { CaseRoleName:'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'F',},
-                { CaseRoleName:'None', HearingRoleName: 'Litigant in Person', FirstName: 'B'},
-                { CaseRoleName:'None', HearingRoleName: 'Litigant in Person', FirstName: 'E'},
-                { CaseRoleName:'None', HearingRoleName: 'Observer', FirstName: 'G'},
-                { CaseRoleName:'Observer', HearingRoleName: 'new observer type', FirstName: 'M'}
-            ]
+                { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'A'},
+                { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'C'},
+                { CaseRoleName: 'None', HearingRoleName: 'Interpreter', FirstName: 'A'},
+                { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'D', },
+                { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'F', },
+                { CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'B'},
+                { CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'E'},
+                { CaseRoleName: 'None', HearingRoleName: 'Observer', FirstName: 'G'},
+                { CaseRoleName: 'Observer', HearingRoleName: 'new observer type', FirstName: 'M'}
+            ];
 
             for (let i = 0; i < expectedOutput.length; i++) {
                 expect(component.sortedParticipants[i].FirstName).toEqual(expectedOutput[i].FirstName);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.spec.ts
@@ -4,6 +4,8 @@ import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ParticipantDetailsModel } from '../../common/model/participant-details.model';
 import { BookingParticipantListComponent } from './booking-participant-list.component';
+import {HearingRoles} from "../../common/model/hearing-roles.model";
+import {LinkedParticipant} from "../../services/clients/api-client";
 
 @Component({
     selector: 'app-booking-participant-details',
@@ -33,7 +35,6 @@ describe('BookingParticipantListComponent', () => {
         fixture = TestBed.createComponent(BookingParticipantListComponent);
         debugElement = fixture.debugElement;
         component = debugElement.componentInstance;
-
         fixture.detectChanges();
     });
 
@@ -58,7 +59,8 @@ describe('BookingParticipantListComponent', () => {
             'Respondent',
             '12345678',
             'interpretee',
-            false
+            false,
+            null
         );
         const participantsList: Array<ParticipantDetailsModel> = [];
         participantsList.push(pr1);
@@ -93,7 +95,8 @@ describe('BookingParticipantListComponent', () => {
             'Respondent',
             '12345678',
             'interpretee',
-            false
+            false,
+            null
         );
         const participantsList: Array<ParticipantDetailsModel> = [];
         participantsList.push(pr1);
@@ -109,4 +112,107 @@ describe('BookingParticipantListComponent', () => {
             done();
         });
     });
+
+    it('should produce a sorted list with specific hierarchy and grouping', done => {
+            //setup
+            function parseTestInput(inputParticipants) {
+                const participantsArray: ParticipantDetailsModel[] = [];
+                inputParticipants.forEach((p, i) => {
+                    participantsArray.push({
+                        FirstName: p.FirstName,
+                        isJudge: p.isJudge ?? false,
+                        HearingRoleName: p.HearingRoleName,
+                        CaseRoleName: p.CaseRoleName,
+                        LinkedParticipants: p.LinkedParticipants ?? null,
+                        ParticipantId: `${i + 1}`,
+                        Company: "",
+                        DisplayName: "",
+                        Email: "",
+                        Flag: false,
+                        IndexInList: 0,
+                        IsInterpretee: false,
+                        Interpretee: p.Interpretee,
+                        LastName: "",
+                        MiddleNames: "",
+                        Phone: "",
+                        Representee: "",
+                        Title: "",
+                        UserName: "",
+                        UserRoleName: "",
+                        get fullName(): string {
+                            return "";
+                        },
+                        get isInterpretee(): boolean {
+                            return false;
+                        },
+                        get isInterpreter(): boolean {
+                            return this.HearingRoleName && this.HearingRoleName.toLowerCase().trim() === HearingRoles.INTERPRETER;
+                        },
+                        get isRepOrInterpreter(): boolean {
+                            return false;
+                        },
+                        get isRepresenting(): boolean {
+                            return undefined;
+                        },
+                        showCaseRole(): boolean {
+                            return false;
+                        }
+                    });
+                });
+                return participantsArray
+            }
+            //input
+            const linked_participantList1: LinkedParticipant[] = [];
+            const linked_interpretee = new LinkedParticipant();
+            linked_interpretee.linked_id = '2';
+            linked_participantList1.push(linked_interpretee);
+
+            const linked_participantList2: LinkedParticipant[] = [];
+            const linked_interpreter = new LinkedParticipant();
+            linked_interpreter.linked_id = '1';
+            linked_participantList2.push(linked_interpreter);
+
+            const participantsInputArray = [
+                {CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'C', LinkedParticipants: linked_participantList1, Interpretee: 'interpretee'},
+                {CaseRoleName: 'None', HearingRoleName: 'Interpreter', FirstName: 'A', LinkedParticipants: linked_participantList2},
+                {isJudge: true, CaseRoleName: null, HearingRoleName: 'Judge', FirstName: 'L'},
+                {CaseRoleName: 'Winger', HearingRoleName: 'None', FirstName: 'K'},
+                {CaseRoleName: 'None', HearingRoleName: 'Winger', FirstName: 'J'},
+                {CaseRoleName: null, HearingRoleName: 'Staff Member', FirstName: 'I'},
+                {CaseRoleName: 'None', HearingRoleName: 'Panel Member', FirstName: 'H'},
+                {CaseRoleName: 'None', HearingRoleName: 'Observer', FirstName: 'G'},
+                {CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'F'},
+                {CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'E'},
+                {CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'D'},
+                {CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'B'},
+                {CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'A'},
+                {CaseRoleName: 'Observer', HearingRoleName: 'new observer type', FirstName: 'M'}
+            ];
+            component.participants = parseTestInput(participantsInputArray);
+            //expected output
+            const expectedOutput=[
+                { CaseRoleName: null, HearingRoleName: 'Judge', FirstName: 'L'},
+                { CaseRoleName:'None', HearingRoleName: 'Panel Member', FirstName: 'H'},
+                { CaseRoleName:'None', HearingRoleName: 'Winger', FirstName: 'J'},
+                { CaseRoleName:'Winger', HearingRoleName: 'None', FirstName: 'K'},
+                { CaseRoleName: null, HearingRoleName: 'Staff Member', FirstName: 'I'},
+                { CaseRoleName:'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'A'},
+                { CaseRoleName:'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'C'},
+                { CaseRoleName:'None', HearingRoleName: 'Interpreter', FirstName: 'A'},
+                { CaseRoleName:'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'D',},
+                { CaseRoleName:'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'F',},
+                { CaseRoleName:'None', HearingRoleName: 'Litigant in Person', FirstName: 'B'},
+                { CaseRoleName:'None', HearingRoleName: 'Litigant in Person', FirstName: 'E'},
+                { CaseRoleName:'None', HearingRoleName: 'Observer', FirstName: 'G'},
+                { CaseRoleName:'Observer', HearingRoleName: 'new observer type', FirstName: 'M'}
+            ]
+
+            for (let i = 0; i < expectedOutput.length; i++) {
+                expect(component.sortedParticipants[i].FirstName).toEqual(expectedOutput[i].FirstName);
+                expect(component.sortedParticipants[i].CaseRoleName).toEqual(expectedOutput[i].CaseRoleName);
+                expect(component.sortedParticipants[i].HearingRoleName).toEqual(expectedOutput[i].HearingRoleName);
+            }
+            done();
+        });
+
 });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.spec.ts
@@ -4,8 +4,8 @@ import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ParticipantDetailsModel } from '../../common/model/participant-details.model';
 import { BookingParticipantListComponent } from './booking-participant-list.component';
-import {HearingRoles} from '../../common/model/hearing-roles.model';
-import {LinkedParticipant} from '../../services/clients/api-client';
+import { HearingRoles } from '../../common/model/hearing-roles.model';
+import { LinkedParticipant } from '../../services/clients/api-client';
 
 @Component({
     selector: 'app-booking-participant-details',
@@ -114,107 +114,110 @@ describe('BookingParticipantListComponent', () => {
     });
 
     it('should produce a sorted list with specific hierarchy and grouping', done => {
-            // setup
-            function parseTestInput(inputParticipants) {
-                const participantsArray: ParticipantDetailsModel[] = [];
-                inputParticipants.forEach((p, i) => {
-                    participantsArray.push({
-                        FirstName: p.FirstName,
-                        isJudge: p.isJudge ?? false,
-                        HearingRoleName: p.HearingRoleName,
-                        CaseRoleName: p.CaseRoleName,
-                        LinkedParticipants: p.LinkedParticipants ?? null,
-                        ParticipantId: `${i + 1}`,
-                        Company: '',
-                        DisplayName: '',
-                        Email: '',
-                        Flag: false,
-                        IndexInList: 0,
-                        IsInterpretee: false,
-                        Interpretee: p.Interpretee,
-                        LastName: '',
-                        MiddleNames: '',
-                        Phone: '',
-                        Representee: '',
-                        Title: '',
-                        UserName: '',
-                        UserRoleName: '',
-                        get fullName(): string {
-                            return '';
-                        },
-                        get isInterpretee(): boolean {
-                            return false;
-                        },
-                        get isInterpreter(): boolean {
-                            return this.HearingRoleName && this.HearingRoleName.toLowerCase().trim() === HearingRoles.INTERPRETER;
-                        },
-                        get isRepOrInterpreter(): boolean {
-                            return false;
-                        },
-                        get isRepresenting(): boolean {
-                            return undefined;
-                        },
-                        showCaseRole(): boolean {
-                            return false;
-                        }
-                    });
+        // setup
+        function parseTestInput(inputParticipants) {
+            const participantsArray: ParticipantDetailsModel[] = [];
+            inputParticipants.forEach((p, i) => {
+                participantsArray.push({
+                    FirstName: p.FirstName,
+                    isJudge: p.isJudge ?? false,
+                    HearingRoleName: p.HearingRoleName,
+                    CaseRoleName: p.CaseRoleName,
+                    LinkedParticipants: p.LinkedParticipants ?? null,
+                    ParticipantId: `${i + 1}`,
+                    Company: '',
+                    DisplayName: '',
+                    Email: '',
+                    Flag: false,
+                    IndexInList: 0,
+                    IsInterpretee: false,
+                    Interpretee: p.Interpretee,
+                    LastName: '',
+                    MiddleNames: '',
+                    Phone: '',
+                    Representee: '',
+                    Title: '',
+                    UserName: '',
+                    UserRoleName: '',
+                    get fullName(): string {
+                        return '';
+                    },
+                    get isInterpretee(): boolean {
+                        return false;
+                    },
+                    get isInterpreter(): boolean {
+                        return this.HearingRoleName && this.HearingRoleName.toLowerCase().trim() === HearingRoles.INTERPRETER;
+                    },
+                    get isRepOrInterpreter(): boolean {
+                        return false;
+                    },
+                    get isRepresenting(): boolean {
+                        return undefined;
+                    },
+                    showCaseRole(): boolean {
+                        return false;
+                    }
                 });
-                return participantsArray;
-            }
-            // input
-            const linked_participantList1: LinkedParticipant[] = [];
-            const linked_interpretee = new LinkedParticipant();
-            linked_interpretee.linked_id = '2';
-            linked_participantList1.push(linked_interpretee);
+            });
+            return participantsArray;
+        }
+        // input
+        const linked_participantList1: LinkedParticipant[] = [];
+        const linked_interpretee = new LinkedParticipant();
+        linked_interpretee.linked_id = '2';
+        linked_participantList1.push(linked_interpretee);
 
-            const linked_participantList2: LinkedParticipant[] = [];
-            const linked_interpreter = new LinkedParticipant();
-            linked_interpreter.linked_id = '1';
-            linked_participantList2.push(linked_interpreter);
+        const linked_participantList2: LinkedParticipant[] = [];
+        const linked_interpreter = new LinkedParticipant();
+        linked_interpreter.linked_id = '1';
+        linked_participantList2.push(linked_interpreter);
 
-            const participantsInputArray = [
-                {CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'C',
-                    LinkedParticipants: linked_participantList1, Interpretee: 'interpretee'},
-                {CaseRoleName: 'None', HearingRoleName: 'Interpreter', FirstName: 'A',
-                    LinkedParticipants: linked_participantList2},
-                {isJudge: true, CaseRoleName: null, HearingRoleName: 'Judge', FirstName: 'L'},
-                {CaseRoleName: 'Winger', HearingRoleName: 'None', FirstName: 'K'},
-                {CaseRoleName: 'None', HearingRoleName: 'Winger', FirstName: 'J'},
-                {CaseRoleName: null, HearingRoleName: 'Staff Member', FirstName: 'I'},
-                {CaseRoleName: 'None', HearingRoleName: 'Panel Member', FirstName: 'H'},
-                {CaseRoleName: 'None', HearingRoleName: 'Observer', FirstName: 'G'},
-                {CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'F'},
-                {CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'E'},
-                {CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'D'},
-                {CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'B'},
-                {CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'A'},
-                {CaseRoleName: 'Observer', HearingRoleName: 'new observer type', FirstName: 'M'}
-            ];
-            component.participants = parseTestInput(participantsInputArray);
-            // expected output
-            const expectedOutput = [
-                { CaseRoleName: null, HearingRoleName: 'Judge', FirstName: 'L'},
-                { CaseRoleName: 'None', HearingRoleName: 'Panel Member', FirstName: 'H'},
-                { CaseRoleName: 'None', HearingRoleName: 'Winger', FirstName: 'J'},
-                { CaseRoleName: 'Winger', HearingRoleName: 'None', FirstName: 'K'},
-                { CaseRoleName: null, HearingRoleName: 'Staff Member', FirstName: 'I'},
-                { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'A'},
-                { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'C'},
-                { CaseRoleName: 'None', HearingRoleName: 'Interpreter', FirstName: 'A'},
-                { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'D', },
-                { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'F', },
-                { CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'B'},
-                { CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'E'},
-                { CaseRoleName: 'None', HearingRoleName: 'Observer', FirstName: 'G'},
-                { CaseRoleName: 'Observer', HearingRoleName: 'new observer type', FirstName: 'M'}
-            ];
+        const participantsInputArray = [
+            {
+                CaseRoleName: 'Appellant',
+                HearingRoleName: 'Litigant in Person',
+                FirstName: 'C',
+                LinkedParticipants: linked_participantList1,
+                Interpretee: 'interpretee'
+            },
+            { CaseRoleName: 'None', HearingRoleName: 'Interpreter', FirstName: 'A', LinkedParticipants: linked_participantList2 },
+            { isJudge: true, CaseRoleName: null, HearingRoleName: 'Judge', FirstName: 'L' },
+            { CaseRoleName: 'Winger', HearingRoleName: 'None', FirstName: 'K' },
+            { CaseRoleName: 'None', HearingRoleName: 'Winger', FirstName: 'J' },
+            { CaseRoleName: null, HearingRoleName: 'Staff Member', FirstName: 'I' },
+            { CaseRoleName: 'None', HearingRoleName: 'Panel Member', FirstName: 'H' },
+            { CaseRoleName: 'None', HearingRoleName: 'Observer', FirstName: 'G' },
+            { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'F' },
+            { CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'E' },
+            { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'D' },
+            { CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'B' },
+            { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'A' },
+            { CaseRoleName: 'Observer', HearingRoleName: 'new observer type', FirstName: 'M' }
+        ];
+        component.participants = parseTestInput(participantsInputArray);
+        // expected output
+        const expectedOutput = [
+            { CaseRoleName: null, HearingRoleName: 'Judge', FirstName: 'L' },
+            { CaseRoleName: 'None', HearingRoleName: 'Panel Member', FirstName: 'H' },
+            { CaseRoleName: 'None', HearingRoleName: 'Winger', FirstName: 'J' },
+            { CaseRoleName: 'Winger', HearingRoleName: 'None', FirstName: 'K' },
+            { CaseRoleName: null, HearingRoleName: 'Staff Member', FirstName: 'I' },
+            { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'A' },
+            { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'C' },
+            { CaseRoleName: 'None', HearingRoleName: 'Interpreter', FirstName: 'A' },
+            { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'D' },
+            { CaseRoleName: 'Appellant', HearingRoleName: 'Litigant in Person', FirstName: 'F' },
+            { CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'B' },
+            { CaseRoleName: 'None', HearingRoleName: 'Litigant in Person', FirstName: 'E' },
+            { CaseRoleName: 'None', HearingRoleName: 'Observer', FirstName: 'G' },
+            { CaseRoleName: 'Observer', HearingRoleName: 'new observer type', FirstName: 'M' }
+        ];
 
-            for (let i = 0; i < expectedOutput.length; i++) {
-                expect(component.sortedParticipants[i].FirstName).toEqual(expectedOutput[i].FirstName);
-                expect(component.sortedParticipants[i].CaseRoleName).toEqual(expectedOutput[i].CaseRoleName);
-                expect(component.sortedParticipants[i].HearingRoleName).toEqual(expectedOutput[i].HearingRoleName);
-            }
-            done();
-        });
-
+        for (let i = 0; i < expectedOutput.length; i++) {
+            expect(component.sortedParticipants[i].FirstName).toEqual(expectedOutput[i].FirstName);
+            expect(component.sortedParticipants[i].CaseRoleName).toEqual(expectedOutput[i].CaseRoleName);
+            expect(component.sortedParticipants[i].HearingRoleName).toEqual(expectedOutput[i].HearingRoleName);
+        }
+        done();
+    });
 });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { ParticipantDetailsModel } from '../../common/model/participant-details.model';
 import { BookingsDetailsModel } from '../../common/model/bookings-list.model';
+import {Constants} from "../../common/constants";
 
 @Component({
     selector: 'app-booking-participant-list',
@@ -20,7 +21,6 @@ export class BookingParticipantListComponent {
     hearing: BookingsDetailsModel;
     @Input()
     judges: Array<ParticipantDetailsModel> = [];
-
     @Input()
     vh_officer_admin: boolean;
 
@@ -36,30 +36,59 @@ export class BookingParticipantListComponent {
     }
 
     private sortParticipants() {
-        const judges = this.participants.filter(participant => participant.HearingRoleName === 'Judge');
+        const compareByPartyThenByFirstName = () => (a, b) => {
+            const partyA = (a.CaseRoleName === Constants.None) ? a.HearingRoleName : a.CaseRoleName;
+            const partyB = (b.CaseRoleName === Constants.None) ? b.HearingRoleName : b.CaseRoleName;
+            if(partyA === partyB){
+                return (a.FirstName < b.FirstName) ? -1 : (a > b) ? 1 : 0;
+            }
+            return (partyA < partyB) ? -1 : (a > b) ? 1 : 0;
+        }
+        const judges = this.participants.filter(participant => participant.HearingRoleName === Constants.Judge);
+        const staffMember = this.participants.filter(participant => participant.HearingRoleName === Constants.HearingRoles.StaffMember );
         const panelMembersAndWingers = this.participants.filter(participant =>
-            ['Panel Member', 'Winger'].includes(participant.HearingRoleName)
-        );
-        const staffMember = this.participants.filter(participant => participant.HearingRoleName === 'Staff Member');
-        const interpretersAndInterpretees = this.participants.filter(
-            participant => participant.HearingRoleName === 'Interpreter' || participant.isInterpretee
-        );
-        const observers = this.participants.filter(participant => participant.HearingRoleName === 'Observer' && !participant.IsInterpretee);
+            Constants.JudiciaryRoles.includes((participant.CaseRoleName === Constants.None)
+                ? participant.HearingRoleName
+                : participant.CaseRoleName)
+        ).sort(compareByPartyThenByFirstName());
+        const interpreters = this.participants.filter(participant => participant.isInterpreter);
+        const observers = this.participants.filter(participant =>
+            Constants.HearingRoles.Observer === ((participant.CaseRoleName === Constants.None)
+                ? participant.HearingRoleName
+                : participant.CaseRoleName));
         const others = this.participants.filter(
             participant =>
                 !judges.includes(participant) &&
                 !panelMembersAndWingers.includes(participant) &&
                 !staffMember.includes(participant) &&
-                !interpretersAndInterpretees.includes(participant) &&
+                !interpreters.includes(participant) &&
                 !observers.includes(participant)
-        );
-        this.sortedParticipants = [
+        ).sort(compareByPartyThenByFirstName());
+        const sorted = [
             ...judges,
             ...panelMembersAndWingers,
             ...staffMember,
             ...others,
-            ...interpretersAndInterpretees,
             ...observers
         ];
+        this.insertInterpreters(interpreters, sorted);
+        this.sortedParticipants = sorted;
+    }
+
+    private insertInterpreters(interpreters: ParticipantDetailsModel[], sorted: ParticipantDetailsModel[]) {
+        interpreters.forEach((interpreterParticipant) => {
+            let interpretee: ParticipantDetailsModel;
+            if (interpreterParticipant.LinkedParticipants) {
+                const linkedParticipants = interpreterParticipant.LinkedParticipants;
+                interpretee = this._participants.find(p => linkedParticipants.some(lp => lp.linked_id === p.ParticipantId)
+                )
+            }
+            if (interpretee) {
+                const insertIndex: number = sorted.findIndex((pdm) => pdm.ParticipantId === interpretee.ParticipantId) + 1;
+                sorted.splice(insertIndex, 0, interpreterParticipant);
+            } else {
+                sorted.push(interpreterParticipant)
+            }
+        });
     }
 }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { ParticipantDetailsModel } from '../../common/model/participant-details.model';
 import { BookingsDetailsModel } from '../../common/model/bookings-list.model';
-import {Constants} from '../../common/constants';
+import { Constants } from '../../common/constants';
 
 @Component({
     selector: 'app-booking-participant-list',
@@ -37,54 +37,52 @@ export class BookingParticipantListComponent {
 
     private sortParticipants() {
         const compareByPartyThenByFirstName = () => (a, b) => {
-            const partyA = (a.CaseRoleName === Constants.None) ? a.HearingRoleName : a.CaseRoleName;
-            const partyB = (b.CaseRoleName === Constants.None) ? b.HearingRoleName : b.CaseRoleName;
+            const partyA = a.CaseRoleName === Constants.None ? a.HearingRoleName : a.CaseRoleName;
+            const partyB = b.CaseRoleName === Constants.None ? b.HearingRoleName : b.CaseRoleName;
             if (partyA === partyB) {
-                return (a.FirstName < b.FirstName) ? -1 : (a > b) ? 1 : 0;
+                return a.FirstName < b.FirstName ? -1 : a > b ? 1 : 0;
             }
-            return (partyA < partyB) ? -1 : (a > b) ? 1 : 0;
+            return partyA < partyB ? -1 : a > b ? 1 : 0;
         };
         const judges = this.participants.filter(participant => participant.HearingRoleName === Constants.Judge);
-        const staffMember = this.participants.filter(participant => participant.HearingRoleName === Constants.HearingRoles.StaffMember );
-        const panelMembersAndWingers = this.participants.filter(participant =>
-            Constants.JudiciaryRoles.includes((participant.CaseRoleName === Constants.None)
-                ? participant.HearingRoleName
-                : participant.CaseRoleName)
-        ).sort(compareByPartyThenByFirstName());
+        const staffMember = this.participants.filter(participant => participant.HearingRoleName === Constants.HearingRoles.StaffMember);
+        const panelMembersAndWingers = this.participants
+            .filter(participant =>
+                Constants.JudiciaryRoles.includes(
+                    participant.CaseRoleName === Constants.None ? participant.HearingRoleName : participant.CaseRoleName
+                )
+            )
+            .sort(compareByPartyThenByFirstName());
         const interpreters = this.participants.filter(participant => participant.isInterpreter);
-        const observers = this.participants.filter(participant =>
-            Constants.HearingRoles.Observer === ((participant.CaseRoleName === Constants.None)
-                ? participant.HearingRoleName
-                : participant.CaseRoleName));
-        const others = this.participants.filter(
+        const observers = this.participants.filter(
             participant =>
-                !judges.includes(participant) &&
-                !panelMembersAndWingers.includes(participant) &&
-                !staffMember.includes(participant) &&
-                !interpreters.includes(participant) &&
-                !observers.includes(participant)
-        ).sort(compareByPartyThenByFirstName());
-        const sorted = [
-            ...judges,
-            ...panelMembersAndWingers,
-            ...staffMember,
-            ...others,
-            ...observers
-        ];
+                Constants.HearingRoles.Observer ===
+                (participant.CaseRoleName === Constants.None ? participant.HearingRoleName : participant.CaseRoleName)
+        );
+        const others = this.participants
+            .filter(
+                participant =>
+                    !judges.includes(participant) &&
+                    !panelMembersAndWingers.includes(participant) &&
+                    !staffMember.includes(participant) &&
+                    !interpreters.includes(participant) &&
+                    !observers.includes(participant)
+            )
+            .sort(compareByPartyThenByFirstName());
+        const sorted = [...judges, ...panelMembersAndWingers, ...staffMember, ...others, ...observers];
         this.insertInterpreters(interpreters, sorted);
         this.sortedParticipants = sorted;
     }
 
     private insertInterpreters(interpreters: ParticipantDetailsModel[], sorted: ParticipantDetailsModel[]) {
-        interpreters.forEach((interpreterParticipant) => {
+        interpreters.forEach(interpreterParticipant => {
             let interpretee: ParticipantDetailsModel;
             if (interpreterParticipant.LinkedParticipants) {
                 const linkedParticipants = interpreterParticipant.LinkedParticipants;
-                interpretee = this._participants.find(p => linkedParticipants.some(lp => lp.linked_id === p.ParticipantId)
-                );
+                interpretee = this._participants.find(p => linkedParticipants.some(lp => lp.linked_id === p.ParticipantId));
             }
             if (interpretee) {
-                const insertIndex: number = sorted.findIndex((pdm) => pdm.ParticipantId === interpretee.ParticipantId) + 1;
+                const insertIndex: number = sorted.findIndex(pdm => pdm.ParticipantId === interpretee.ParticipantId) + 1;
                 sorted.splice(insertIndex, 0, interpreterParticipant);
             } else {
                 sorted.push(interpreterParticipant);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { ParticipantDetailsModel } from '../../common/model/participant-details.model';
 import { BookingsDetailsModel } from '../../common/model/bookings-list.model';
-import {Constants} from "../../common/constants";
+import {Constants} from '../../common/constants';
 
 @Component({
     selector: 'app-booking-participant-list',
@@ -39,11 +39,11 @@ export class BookingParticipantListComponent {
         const compareByPartyThenByFirstName = () => (a, b) => {
             const partyA = (a.CaseRoleName === Constants.None) ? a.HearingRoleName : a.CaseRoleName;
             const partyB = (b.CaseRoleName === Constants.None) ? b.HearingRoleName : b.CaseRoleName;
-            if(partyA === partyB){
+            if (partyA === partyB) {
                 return (a.FirstName < b.FirstName) ? -1 : (a > b) ? 1 : 0;
             }
             return (partyA < partyB) ? -1 : (a > b) ? 1 : 0;
-        }
+        };
         const judges = this.participants.filter(participant => participant.HearingRoleName === Constants.Judge);
         const staffMember = this.participants.filter(participant => participant.HearingRoleName === Constants.HearingRoles.StaffMember );
         const panelMembersAndWingers = this.participants.filter(participant =>
@@ -81,13 +81,13 @@ export class BookingParticipantListComponent {
             if (interpreterParticipant.LinkedParticipants) {
                 const linkedParticipants = interpreterParticipant.LinkedParticipants;
                 interpretee = this._participants.find(p => linkedParticipants.some(lp => lp.linked_id === p.ParticipantId)
-                )
+                );
             }
             if (interpretee) {
                 const insertIndex: number = sorted.findIndex((pdm) => pdm.ParticipantId === interpretee.ParticipantId) + 1;
                 sorted.splice(insertIndex, 0, interpreterParticipant);
             } else {
-                sorted.push(interpreterParticipant)
+                sorted.push(interpreterParticipant);
             }
         });
     }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.ts
@@ -37,7 +37,7 @@ export class BookingParticipantListComponent {
 
     private sortParticipants() {
         const compareByPartyThenByFirstName = () => (a, b) => {
-            const swapIndices = a > b ? 1 : 0
+            const swapIndices = a > b ? 1 : 0;
             const partyA = a.CaseRoleName === Constants.None ? a.HearingRoleName : a.CaseRoleName;
             const partyB = b.CaseRoleName === Constants.None ? b.HearingRoleName : b.CaseRoleName;
             if (partyA === partyB) {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-participant-list/booking-participant-list.component.ts
@@ -37,12 +37,13 @@ export class BookingParticipantListComponent {
 
     private sortParticipants() {
         const compareByPartyThenByFirstName = () => (a, b) => {
+            const swapIndices = a > b ? 1 : 0
             const partyA = a.CaseRoleName === Constants.None ? a.HearingRoleName : a.CaseRoleName;
             const partyB = b.CaseRoleName === Constants.None ? b.HearingRoleName : b.CaseRoleName;
             if (partyA === partyB) {
-                return a.FirstName < b.FirstName ? -1 : a > b ? 1 : 0;
+                return a.FirstName < b.FirstName ? -1 : swapIndices;
             }
-            return partyA < partyB ? -1 : a > b ? 1 : 0;
+            return partyA < partyB ? -1 : swapIndices;
         };
         const judges = this.participants.filter(participant => participant.HearingRoleName === Constants.Judge);
         const staffMember = this.participants.filter(participant => participant.HearingRoleName === Constants.HearingRoles.StaffMember);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/hearing-details/hearing-details.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/hearing-details/hearing-details.component.spec.ts
@@ -108,7 +108,8 @@ describe('HearingDetailsComponent', () => {
             'representee',
             '12345678',
             'interpretee',
-            false
+            false,
+            null
         );
         participants.push(participant);
         component.participants = participants;
@@ -133,7 +134,8 @@ describe('HearingDetailsComponent', () => {
             'representee',
             '',
             'interpretee',
-            false
+            false,
+            null
         );
         participants.push(participant);
         component.participants = participants;

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/participant-details/participant-details.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/participant-details/participant-details.component.spec.ts
@@ -69,7 +69,8 @@ describe('ParticipantDetailsComponent', () => {
             'Respondent',
             '12345678',
             'interpretee',
-            false
+            false,
+            null
         );
         pr.IndexInList = 0;
         component.participant = pr;
@@ -113,7 +114,8 @@ describe('ParticipantDetailsComponent', () => {
             'Judge',
             '12345678',
             'N/A',
-            false
+            false,
+            null
         );
         pr.HearingRoleName = HearingRoles.JUDGE;
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
@@ -50,7 +50,8 @@ export const Constants = {
         StaffMember: 'Staff Member',
         Winger: 'Winger',
         PanelMember: 'Panel Member',
-        Observer: 'Observer'
+        Observer: 'Observer',
+        Interpreter: 'Interpreter'
     },
     OtherParticipantRoles: ['Staff Member', 'Observer', 'Panel Member', 'Winger']
 };

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.spec.ts
@@ -19,7 +19,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
 
         expect(model.fullName).toEqual('title first_name last_name');
@@ -42,7 +43,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
 
         expect(model.fullName).toEqual('Judge last_name');
@@ -65,7 +67,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
 
         expect(model.fullName).toEqual('first_name Judge');
@@ -88,7 +91,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
         expect(ParticipantModel.IsEmailEjud(model.Email)).toBeFalsy();
     });
@@ -109,7 +113,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
         expect(ParticipantModel.IsEmailEjud(model.Email)).toBeTruthy();
     });
@@ -130,7 +135,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
 
         expect(model.isRepresenting).toBeTruthy();
@@ -153,7 +159,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
 
         expect(model.isRepresenting).toBeFalsy();
@@ -175,7 +182,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
         expect(model.showCaseRole()).toBeFalsy();
     });
@@ -196,7 +204,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'staffmember',
-            false
+            false,
+            null
         );
         expect(model.showCaseRole()).toBeFalsy();
     });
@@ -217,7 +226,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
         expect(model.showCaseRole()).toBeFalsy();
     });
@@ -238,7 +248,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
         expect(model.showCaseRole()).toBeTruthy();
     });
@@ -259,7 +270,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
         expect(model.isInterpreter).toBeTruthy();
     });
@@ -280,7 +292,8 @@ describe('participant details model', () => {
             'representee',
             '007867678678',
             'interpretee',
-            false
+            false,
+            null
         );
         expect(model.isRepOrInterpreter).toBeTruthy();
     });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.ts
@@ -1,5 +1,6 @@
-import { CaseRoles } from '../model/case-roles';
+import { CaseRoles } from './case-roles';
 import { HearingRoles } from './hearing-roles.model';
+import {LinkedParticipant} from "../../services/clients/api-client";
 
 export class ParticipantDetailsModel {
     constructor(
@@ -18,7 +19,8 @@ export class ParticipantDetailsModel {
         representee: string,
         phone: string,
         interpretee: string,
-        isInterpretee: boolean
+        isInterpretee: boolean,
+        linkedParticipants: LinkedParticipant[]
     ) {
         this.ParticipantId = participantId;
         this.FirstName = firstName == null ? '' : firstName;
@@ -37,6 +39,7 @@ export class ParticipantDetailsModel {
         this.Phone = phone;
         this.Interpretee = interpretee;
         this.IsInterpretee = isInterpretee;
+        this.linkedParticipants = linkedParticipants;
     }
 
     ParticipantId: string;
@@ -55,7 +58,7 @@ export class ParticipantDetailsModel {
     Phone: string;
     Interpretee: string;
     IsInterpretee: boolean;
-
+    linkedParticipants: LinkedParticipant[]
     // flag to indicate if participant is the last in the list and don't need decoration bottom line
     Flag: boolean;
 
@@ -75,12 +78,10 @@ export class ParticipantDetailsModel {
     }
 
     showCaseRole(): boolean {
-        return this.CaseRoleName.toLowerCase() === CaseRoles.NONE.toLowerCase() ||
+        return !(this.CaseRoleName.toLowerCase() === CaseRoles.NONE.toLowerCase() ||
             this.CaseRoleName.toLowerCase() === CaseRoles.OBSERVER.toLowerCase() ||
             this.CaseRoleName.toLowerCase() === CaseRoles.PANEL_MEMBER.toLowerCase() ||
-            this.CaseRoleName.toLowerCase() === CaseRoles.STAFF_MEMBER.toLowerCase()
-            ? false
-            : true;
+            this.CaseRoleName.toLowerCase() === CaseRoles.STAFF_MEMBER.toLowerCase());
     }
 
     get isInterpreter(): boolean {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.ts
@@ -39,7 +39,7 @@ export class ParticipantDetailsModel {
         this.Phone = phone;
         this.Interpretee = interpretee;
         this.IsInterpretee = isInterpretee;
-        this.linkedParticipants = linkedParticipants;
+        this.LinkedParticipants = linkedParticipants;
     }
 
     ParticipantId: string;
@@ -58,7 +58,7 @@ export class ParticipantDetailsModel {
     Phone: string;
     Interpretee: string;
     IsInterpretee: boolean;
-    linkedParticipants: LinkedParticipant[]
+    LinkedParticipants: LinkedParticipant[]
     // flag to indicate if participant is the last in the list and don't need decoration bottom line
     Flag: boolean;
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.ts
@@ -1,6 +1,6 @@
 import { CaseRoles } from './case-roles';
 import { HearingRoles } from './hearing-roles.model';
-import {LinkedParticipant} from '../../services/clients/api-client';
+import { LinkedParticipant } from '../../services/clients/api-client';
 
 export class ParticipantDetailsModel {
     constructor(
@@ -78,10 +78,12 @@ export class ParticipantDetailsModel {
     }
 
     showCaseRole(): boolean {
-        return !(this.CaseRoleName.toLowerCase() === CaseRoles.NONE.toLowerCase() ||
+        return !(
+            this.CaseRoleName.toLowerCase() === CaseRoles.NONE.toLowerCase() ||
             this.CaseRoleName.toLowerCase() === CaseRoles.OBSERVER.toLowerCase() ||
             this.CaseRoleName.toLowerCase() === CaseRoles.PANEL_MEMBER.toLowerCase() ||
-            this.CaseRoleName.toLowerCase() === CaseRoles.STAFF_MEMBER.toLowerCase());
+            this.CaseRoleName.toLowerCase() === CaseRoles.STAFF_MEMBER.toLowerCase()
+        );
     }
 
     get isInterpreter(): boolean {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-details.model.ts
@@ -1,6 +1,6 @@
 import { CaseRoles } from './case-roles';
 import { HearingRoles } from './hearing-roles.model';
-import {LinkedParticipant} from "../../services/clients/api-client";
+import {LinkedParticipant} from '../../services/clients/api-client';
 
 export class ParticipantDetailsModel {
     constructor(
@@ -58,7 +58,7 @@ export class ParticipantDetailsModel {
     Phone: string;
     Interpretee: string;
     IsInterpretee: boolean;
-    LinkedParticipants: LinkedParticipant[]
+    LinkedParticipants: LinkedParticipant[];
     // flag to indicate if participant is the last in the list and don't need decoration bottom line
     Flag: boolean;
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/booking-details.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/booking-details.service.ts
@@ -62,7 +62,8 @@ export class BookingDetailsService {
                     p.representee,
                     p.telephone_number,
                     this.getInterpretee(hearingResponse, p),
-                    this.isInterpretee(p)
+                    this.isInterpretee(p),
+                    p.linked_participants
                 );
                 // model.Interpretee = this.getInterpretee(hearingResponse, p);
                 if (p.user_role_name === this.JUDGE) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8784


### Change description ###
Have added new sorting logic to the 'participant-list' and 'booking-participant-list' components. Added an additional property to the participant-detail model, linkedParticipants (which was already being sent over in the payload thats mapped into it.). This is to allow us to insert the interpreter below the their interpretee, via the link participant id.  Have had to update a few unit tests that use this model so they compile properly, thus the change looks abit bigger than it actually is.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
