### PR TITLE
VIH-8812 Fix for interpreter incorrectly showing in hearing role selection when valid interpretee (not appraiser/observer) exists already

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant-base/add-participant-base.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant-base/add-participant-base.component.ts
@@ -324,7 +324,7 @@ export abstract class AddParticipantBaseDirective extends BookingBaseComponent i
 
     private hearingHasInterpretees(): boolean {
         return this.hearing.participants.some(
-            p => p.user_role_name === 'Individual' && p.hearing_role_name !== Constants.HearingRoles.Interpreter && this.isNotAnObserver(p)
+            p => p.user_role_name === 'Individual' && p.hearing_role_name !== Constants.HearingRoles.Interpreter && !this.isAnObserver(p)
         );
     }
 
@@ -398,9 +398,9 @@ export abstract class AddParticipantBaseDirective extends BookingBaseComponent i
         }
     }
 
-    protected isNotAnObserver(participant): boolean {
+    protected isAnObserver(participant): boolean {
         return participant.case_role_name === Constants.None
-            ? participant.hearing_role_name !== Constants.HearingRoles.Observer
-            : participant.case_role_name !== Constants.HearingRoles.Observer;
+            ? participant.hearing_role_name === Constants.HearingRoles.Observer
+            : participant.case_role_name === Constants.HearingRoles.Observer;
     }
 }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant-base/add-participant-base.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant-base/add-participant-base.component.ts
@@ -323,11 +323,9 @@ export abstract class AddParticipantBaseDirective extends BookingBaseComponent i
     }
 
     private hearingHasInterpretees(): boolean {
-        const notAllowedInterpreter = [HearingRoles.INTERPRETER.toLowerCase(), HearingRoles.OBSERVER.toLowerCase()];
-        const hearingHasInterpretees = this.hearing.participants.some(
-            p => p.user_role_name === 'Individual' && !notAllowedInterpreter.includes(p.hearing_role_name.toLowerCase())
+        return this.hearing.participants.some(
+            p => p.user_role_name === 'Individual' && p.hearing_role_name !== Constants.HearingRoles.Interpreter && this.isNotAnObserver(p)
         );
-        return hearingHasInterpretees;
     }
 
     private hearingHasAnInterpreter(): boolean {
@@ -386,6 +384,7 @@ export abstract class AddParticipantBaseDirective extends BookingBaseComponent i
     private isRoleInterpreter(hearingRole: string): boolean {
         return hearingRole.toLowerCase() === HearingRoles.INTERPRETER.toLowerCase();
     }
+
     private setInterpreterForValidation() {
         if (this.isRoleInterpreter(this.role.value)) {
             this.interpreterFor.setValidators([Validators.required, Validators.pattern(Constants.PleaseSelectPattern)]);
@@ -397,5 +396,11 @@ export abstract class AddParticipantBaseDirective extends BookingBaseComponent i
             this.interpreterFor.setValue(Constants.PleaseSelect);
             this.isInterpreter = false;
         }
+    }
+
+    protected isNotAnObserver(participant): boolean {
+        return participant.case_role_name === Constants.None
+            ? participant.hearing_role_name !== Constants.HearingRoles.Observer
+            : participant.case_role_name !== Constants.HearingRoles.Observer;
     }
 }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.spec.ts
@@ -651,6 +651,31 @@ describe('AddParticipantComponent', () => {
         tick(600);
         expect(component.hearingRoleList).not.toContain('Interpreter');
     }));
+    it('should not show the interpreter option in hearings role if observer/appraiser participant is added.', fakeAsync(() => {
+        component.ngOnInit();
+        component.ngAfterViewInit();
+        tick(600);
+        component.hearing.participants = [];
+        expect(component.hearingRoleList).toContain('Interpreter');
+        component.setupHearingRoles('Observer');
+        expect(component.hearingRoleList).not.toContain('Interpreter');
+        let participant01 = new ParticipantModel();
+        participant01.first_name = 'firstName';
+        participant01.last_name = 'lastName';
+        participant01.hearing_role_name = 'Observer';
+        participant01.case_role_name = 'Observer';
+        participant01.user_role_name = 'Individual';
+        component.hearing.participants.push(participant01);
+        participant01 = new ParticipantModel();
+        participant01.first_name = 'firstName';
+        participant01.last_name = 'lastName';
+        participant01.hearing_role_name = 'Appraiser';
+        participant01.case_role_name = 'Observer';
+        participant01.user_role_name = 'Individual';
+        component.hearing.participants.push(participant01);
+        tick(600);
+        expect(component.hearingRoleList).not.toContain('Interpreter');
+    }));
     it('should validate the interpreter drop down', () => {
         component.ngOnInit();
         component.ngAfterViewInit();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.ts
@@ -710,7 +710,7 @@ export class AddParticipantComponent extends AddParticipantBaseDirective impleme
 
     private populateInterpretedForList() {
         this.interpreteeList = this.hearing.participants.filter(
-            p => p.user_role_name === 'Individual' && p.hearing_role_name !== Constants.HearingRoles.Interpreter && this.isNotAnObserver(p)
+            p => p.user_role_name === 'Individual' && p.hearing_role_name !== Constants.HearingRoles.Interpreter && !this.isAnObserver(p)
         );
 
         const interpreteeModel: ParticipantModel = {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.ts
@@ -709,13 +709,8 @@ export class AddParticipantComponent extends AddParticipantBaseDirective impleme
     }
 
     private populateInterpretedForList() {
-        const notAnObserver = participant =>
-            participant.case_role_name === Constants.None
-                ? participant.hearing_role_name !== Constants.HearingRoles.Observer
-                : participant.case_role_name !== Constants.HearingRoles.Observer;
-
         this.interpreteeList = this.hearing.participants.filter(
-            p => p.user_role_name === 'Individual' && p.hearing_role_name !== Constants.HearingRoles.Interpreter && notAnObserver(p)
+            p => p.user_role_name === 'Individual' && p.hearing_role_name !== Constants.HearingRoles.Interpreter && this.isNotAnObserver(p)
         );
 
         const interpreteeModel: ParticipantModel = {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8812


### Change description ###
Moved notObserver logic up to base class and now utilising this same logic for populating hearing role list, so that an interpreter can not be added if an observer/appraiser exists only. Also added supporting unit test.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
