### PR TITLE
VIH-8792 Booking timeout exception for large multi day booking ranges

### DIFF
--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
@@ -674,6 +674,10 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 x => x.CloneHearingAsync(It.IsAny<Guid>(), It.IsAny<CloneHearingRequest>()),
                 Times.Exactly(1));
 
+            _mocker.Mock<IBookingsApiClient>().Verify(
+                x => x.UpdateBookingStatusAsync(It.IsAny<Guid>(), It.Is<UpdateBookingStatusRequest>(r => r.Status == UpdateBookingStatus.Created)),
+                Times.Exactly(batchSize));
+            
             foreach (var hearing in groupedHearings)
             {
                 _mocker.Mock<IBookingsApiClient>().Verify(

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
@@ -637,10 +637,9 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         }
 
         [Test]
-        public async Task Should_clone_and_confirm_hearing_with_large_batch()
+        public async Task Should_clone_and_confirm_hearing_for_large_booking()
         {
             var request = GetMultiHearingRequest();
-            var status = BookingsApi.Contract.Enums.BookingStatus.Booked;
             var hearingGroupId = Guid.NewGuid();
             var groupedHearings = new List<HearingDetailsResponse>();
             var batchSize = 30;

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
@@ -200,8 +200,8 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             _mocker.Mock<IBookingsApiClient>().Verify(x => x.UpdateBookingStatusAsync(hearingId, request), Times.Once);
             
-            _mocker.Mock<IHearingsService>().Verify(
-                x => x.SendHearingReminderEmail(It.Is<HearingDetailsResponse>(x => x == hearing)), Times.AtLeast(1));
+            // _mocker.Mock<IHearingsService>().Verify(
+            //     x => x.SendHearingReminderEmail(It.Is<HearingDetailsResponse>(x => x == hearing)), Times.AtLeast(1));
         }
 
         [Test]

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
@@ -199,9 +199,6 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             result.Value.Should().NotBeNull().And.BeAssignableTo<UpdateBookingStatusResponse>().Subject.TelephoneConferenceId.Should().Be("121212");
 
             _mocker.Mock<IBookingsApiClient>().Verify(x => x.UpdateBookingStatusAsync(hearingId, request), Times.Once);
-            
-            // _mocker.Mock<IHearingsService>().Verify(
-            //     x => x.SendHearingReminderEmail(It.Is<HearingDetailsResponse>(x => x == hearing)), Times.AtLeast(1));
         }
 
         [Test]

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
@@ -199,6 +199,9 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             result.Value.Should().NotBeNull().And.BeAssignableTo<UpdateBookingStatusResponse>().Subject.TelephoneConferenceId.Should().Be("121212");
 
             _mocker.Mock<IBookingsApiClient>().Verify(x => x.UpdateBookingStatusAsync(hearingId, request), Times.Once);
+            
+            _mocker.Mock<IHearingsService>().Verify(
+                x => x.SendHearingReminderEmail(It.Is<HearingDetailsResponse>(x => x == hearing)), Times.AtLeast(1));
         }
 
         [Test]

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -116,7 +116,7 @@ namespace AdminWebsite.Controllers
                 _logger.LogInformation("BookNewHearing - Successfully booked hearing {Hearing}",
                     hearingDetailsResponse.Id);
                 
-                //if(_featureToggles.BookAndConfirmToggle())
+                if(_featureToggles.BookAndConfirmToggle())
                     await ConfirmHearing(hearingDetailsResponse.Id);
 
                 _logger.LogInformation("BookNewHearing - Sending email notification to the participants");
@@ -242,7 +242,7 @@ namespace AdminWebsite.Controllers
                 await _bookingsApiClient.CloneHearingAsync(hearingId, cloneHearingRequest);
                 _logger.LogDebug("Successfully cloned hearing {Hearing}", hearingId);
 
-                //if(_featureToggles.BookAndConfirmToggle())
+                if(_featureToggles.BookAndConfirmToggle())
                     await ConfirmHearing(hearingId, true);
 
                 return NoContent();
@@ -549,12 +549,12 @@ namespace AdminWebsite.Controllers
                     if (conferenceDetailsResponse.HasValidMeetingRoom())
                     {
                         //if toggle off - send Hearing Reminder Email
-                        // if (!_featureToggles.BookAndConfirmToggle())
-                        // {
-                        //     var hearing = await _bookingsApiClient.GetHearingDetailsByIdAsync(hearingId);
-                        //     _logger.LogInformation("Sending a reminder email for hearing {Hearing}", hearingId);
-                        //     await _hearingsService.SendHearingReminderEmail(hearing);
-                        // }
+                        if (!_featureToggles.BookAndConfirmToggle())
+                        {
+                            var hearing = await _bookingsApiClient.GetHearingDetailsByIdAsync(hearingId);
+                            _logger.LogInformation("Sending a reminder email for hearing {Hearing}", hearingId);
+                            await _hearingsService.SendHearingReminderEmail(hearing);
+                        }
                         return Ok(new UpdateBookingStatusResponse
                         {
                             Success = true,

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -166,10 +166,15 @@ namespace AdminWebsite.Controllers
                 var groupedHearings = await _bookingsApiClient.GetHearingsByGroupIdAsync(hearingIdOrGroupId);
                 var unConfirmedHearingsList = groupedHearings.Where(b => b.Status != BookingStatus.Created);
 
+                var updateBookingStatusTasks = new List<Task<IActionResult>>();
+
                 foreach (var hearing in unConfirmedHearingsList)
                 {
-                    await UpdateBookingStatus(hearing.Id, updateBookingStatusRequest);
+                    var task = UpdateBookingStatus(hearing.Id, updateBookingStatusRequest);
+                    updateBookingStatusTasks.Add(task);
                 }
+                
+                await Task.WhenAll(updateBookingStatusTasks);
             }
             else
             {

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -178,7 +178,7 @@ namespace AdminWebsite.Controllers
         private async Task UpdateMultipleBookingStatuses(IReadOnlyCollection<Guid> hearingIds, UpdateBookingStatusRequest updateBookingStatusRequest)
         {
             var batchSize = 20;
-            var batchCount = (int)Math.Ceiling((double)hearingIds.Count() / batchSize);
+            var batchCount = (int)Math.Ceiling((double)hearingIds.Count / batchSize);
                 
             for (int i = 0; i < batchCount; i++)
             {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8792

### Change description ###
Fixes an issue where the request to book a long hearing (25 days+) times out when the book + confirm feature is enabled.

The issue is addressed by doing the confirmations in parallel rather than sequentially.

The confirmations are performed in batches to limit the number of threads created at once.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
