### PR TITLE
VIH-8923 Booking details back button sometimes taking you to the wrong page

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list-routing.module.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list-routing.module.spec.ts
@@ -22,6 +22,7 @@ import { routes } from './bookings-list-routing.module';
 import { BookingsListComponent } from './bookings-list/bookings-list.component';
 import { HearingDetailsComponent } from './hearing-details/hearing-details.component';
 import { ParticipantDetailsComponent } from './participant-details/participant-details.component';
+import { DatePipe } from '@angular/common';
 
 describe('BookingsListRouting', () => {
     let location: Location;
@@ -54,7 +55,8 @@ describe('BookingsListRouting', () => {
                 HttpClient,
                 HttpHandler,
                 { provide: Logger, useValue: loggerSpy },
-                { provide: ConfigService, useValue: configServiceSpy }
+                { provide: ConfigService, useValue: configServiceSpy },
+                DatePipe
             ]
         }).compileComponents();
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
@@ -457,7 +457,7 @@ export class BookingPersistServiceSpy {
     private _selectedItemIndex = 0;
     private _caseNumber = 'CASE_NUMBER';
     private _searchTerm = 'SEARCH_VALUE';
-    private _showSearch: boolean = false;
+    private _showSearch = false;
 
     get bookingList() {
         const listItem = new BookingslistTestData().getTestData();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
@@ -1100,4 +1100,19 @@ describe('BookingsListComponent', () => {
         component.ngOnDestroy();
         expect(component.$subcription.closed).toBeTruthy();
     });
+
+    describe('ngOnInit', () => {
+        it('should load persisted information', () => {
+            const showSearch = true;
+            const startDate = new Date(2022, 3, 11);
+            const endDate = new Date(2022, 3, 12);
+            bookingPersistService.showSearch = showSearch;
+            bookingPersistService.startDate = startDate;
+            bookingPersistService.endDate = endDate;
+            component.ngOnInit();
+            expect(component.showSearch).toBe(showSearch);
+            expect(component.searchForm.controls.startDate.value).toEqual('2022-04-11');
+            expect(component.searchForm.controls.endDate.value).toEqual('2022-04-12');
+        });
+    });
 });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
@@ -12,6 +12,8 @@ import { ConfigService } from 'src/app/services/config.service';
 import { LaunchDarklyService } from 'src/app/services/launch-darkly.service';
 import { Logger } from 'src/app/services/logger';
 import { ReferenceDataService } from 'src/app/services/reference-data.service';
+import { ReturnUrlService } from 'src/app/services/return-url.service';
+import { PageUrls } from 'src/app/shared/page-url.constants';
 import { LongDatetimePipe } from '../../../app/shared/directives/date-time.pipe';
 import { BookingsDetailsModel, BookingsListModel } from '../../common/model/bookings-list.model';
 import { BookingsModel } from '../../common/model/bookings.model';
@@ -51,6 +53,7 @@ let referenceDataServiceSpy: jasmine.SpyObj<ReferenceDataService>;
 referenceDataServiceSpy = jasmine.createSpyObj('ReferenceDataService', ['getCourts', 'fetchPublicHolidays', 'getPublicHolidays']);
 let launchDarklyServiceSpy: jasmine.SpyObj<LaunchDarklyService>;
 launchDarklyServiceSpy = jasmine.createSpyObj('LaunchDarklyService', ['flagChange']);
+let returnUrlService: ReturnUrlService;
 
 export class ResponseTestData {
     getTestData(): BookingsResponse {
@@ -563,6 +566,7 @@ describe('BookingsListComponent', () => {
             fixture = TestBed.createComponent(BookingsListComponent);
             component = fixture.componentInstance;
             bookingPersistService = TestBed.inject(BookingPersistService);
+            returnUrlService = TestBed.inject(ReturnUrlService);
             fixture.detectChanges();
         })
     );
@@ -1066,6 +1070,11 @@ describe('BookingsListComponent', () => {
         component.resetBookingIndex(booking);
         expect(component.selectedGroupIndex).toBe(-1);
         expect(component.selectedItemIndex).toBe(-1);
+    });
+    it('should persist information after row selected', () => {
+        component.bookings = new ArrayBookingslistModelTestData().getTestData();
+        component.rowSelected(1, 0);
+        expect(returnUrlService.popUrl()).toEqual(PageUrls.BookingsList);
     });
     it('should get booking details by Id from data store', fakeAsync(async () => {
         await component.getEditedBookingFromStorage();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
@@ -456,6 +456,8 @@ export class BookingPersistServiceSpy {
     private _selectedGroupIndex = 0;
     private _selectedItemIndex = 0;
     private _caseNumber = 'CASE_NUMBER';
+    private _searchTerm = 'SEARCH_VALUE';
+    private _showSearch: boolean = false;
 
     get bookingList() {
         const listItem = new BookingslistTestData().getTestData();
@@ -494,6 +496,14 @@ export class BookingPersistServiceSpy {
     set caseNumber(value) {
         this._caseNumber = value;
     }
+    get showSearch(): boolean {
+        return this._showSearch;
+    }
+
+    set showSearch(value) {
+        this._showSearch = value;
+    }
+
     updateBooking(hearing: HearingModel) {
         const booking = new BookingsDetailsModel(
             '1',
@@ -1078,7 +1088,7 @@ describe('BookingsListComponent', () => {
         component.bookings = new ArrayBookingslistModelTestData().getTestData();
         component.rowSelected(1, 0);
         expect(returnUrlService.popUrl()).toEqual(PageUrls.BookingsList);
-        expect(bookingPersistService.showSearch).toEqual(component.showSearch);
+        expect(bookingPersistService.showSearch).toBe(true);
     });
     it('should get booking details by Id from data store', fakeAsync(async () => {
         await component.getEditedBookingFromStorage();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
@@ -30,6 +30,7 @@ import {
 } from '../../services/clients/api-client';
 import { VideoHearingsService } from '../../services/video-hearings.service';
 import { BookingsListComponent } from './bookings-list.component';
+import { DatePipe } from '@angular/common';
 
 let component: BookingsListComponent;
 let bookingPersistService: BookingPersistService;
@@ -559,7 +560,8 @@ describe('BookingsListComponent', () => {
                     { provide: BookingPersistService, useClass: BookingPersistServiceSpy },
                     { provide: Logger, useValue: loggerSpy },
                     { provide: LaunchDarklyService, useValue: launchDarklyServiceSpy },
-                    { provide: ReferenceDataService, useValue: referenceDataServiceSpy }
+                    { provide: ReferenceDataService, useValue: referenceDataServiceSpy },
+                    DatePipe
                 ]
             }).compileComponents();
 
@@ -1072,9 +1074,11 @@ describe('BookingsListComponent', () => {
         expect(component.selectedItemIndex).toBe(-1);
     });
     it('should persist information after row selected', () => {
+        component.openSearchPanel();
         component.bookings = new ArrayBookingslistModelTestData().getTestData();
         component.rowSelected(1, 0);
         expect(returnUrlService.popUrl()).toEqual(PageUrls.BookingsList);
+        expect(bookingPersistService.showSearch).toEqual(component.showSearch);
     });
     it('should get booking details by Id from data store', fakeAsync(async () => {
         await component.getEditedBookingFromStorage();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.ts
@@ -76,6 +76,7 @@ export class BookingsListComponent implements OnInit, OnDestroy {
 
     async ngOnInit() {
         this.searchForm = this.initializeForm();
+        this.showSearch = this.bookingPersistService.showSearch;
 
         this.logger.debug(`${this.loggerPrefix} Loading bookings list component`);
         if (this.bookingPersistService.bookingList.length > 0) {
@@ -327,6 +328,7 @@ export class BookingsListComponent implements OnInit, OnDestroy {
         // hearing id is stored in session storage
         this.bookingPersistService.selectedHearingId = this.selectedHearingId;
         this.returnUrlService.setUrl(`${PageUrls.BookingsList}`);
+        this.bookingPersistService.showSearch = this.showSearch;
     }
 
     closeHearingDetails() {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.ts
@@ -1,4 +1,4 @@
-import { DOCUMENT } from '@angular/common';
+import { DOCUMENT, DatePipe } from '@angular/common';
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -15,7 +15,6 @@ import { PageUrls } from '../../shared/page-url.constants';
 import { ReferenceDataService } from 'src/app/services/reference-data.service';
 import * as moment from 'moment';
 import { ReturnUrlService } from 'src/app/services/return-url.service';
-import { DatePipe } from '@angular/common';
 
 @Component({
     selector: 'app-bookings-list',

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.ts
@@ -15,6 +15,7 @@ import { PageUrls } from '../../shared/page-url.constants';
 import { ReferenceDataService } from 'src/app/services/reference-data.service';
 import * as moment from 'moment';
 import { ReturnUrlService } from 'src/app/services/return-url.service';
+import { DatePipe } from '@angular/common';
 
 @Component({
     selector: 'app-bookings-list',
@@ -57,6 +58,7 @@ export class BookingsListComponent implements OnInit, OnDestroy {
         private router: Router,
         private logger: Logger,
         private refDataService: ReferenceDataService,
+        private datePipe: DatePipe,
         private returnUrlService: ReturnUrlService,
         @Inject(DOCUMENT) document
     ) {
@@ -146,8 +148,8 @@ export class BookingsListComponent implements OnInit, OnDestroy {
             caseNumber: [this.bookingPersistService.caseNumber || null],
             selectedVenueIds: [this.bookingPersistService.selectedVenueIds || []],
             selectedCaseTypes: [this.bookingPersistService.selectedCaseTypes || []],
-            startDate: [this.bookingPersistService.startDate || null],
-            endDate: [this.bookingPersistService.endDate || null],
+            startDate: [this.formatDateToIsoString(this.bookingPersistService.startDate)],
+            endDate: [this.formatDateToIsoString(this.bookingPersistService.endDate)],
             participantLastName: [this.bookingPersistService.participantLastName || null]
         });
     }
@@ -452,6 +454,14 @@ export class BookingsListComponent implements OnInit, OnDestroy {
         }
 
         return false;
+    }
+
+    formatDateToIsoString(date?: Date) {
+        if (!date) {
+            return null;
+        }
+
+        return this.datePipe.transform(date, 'yyyy-MM-dd');
     }
 
     ngOnDestroy() {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.ts
@@ -14,6 +14,7 @@ import { FeatureFlags, LaunchDarklyService } from '../../services/launch-darkly.
 import { PageUrls } from '../../shared/page-url.constants';
 import { ReferenceDataService } from 'src/app/services/reference-data.service';
 import * as moment from 'moment';
+import { ReturnUrlService } from 'src/app/services/return-url.service';
 
 @Component({
     selector: 'app-bookings-list',
@@ -56,6 +57,7 @@ export class BookingsListComponent implements OnInit, OnDestroy {
         private router: Router,
         private logger: Logger,
         private refDataService: ReferenceDataService,
+        private returnUrlService: ReturnUrlService,
         @Inject(DOCUMENT) document
     ) {
         this.$ldSubcription = this.lanchDarklyService.flagChange.subscribe(value => {
@@ -322,6 +324,7 @@ export class BookingsListComponent implements OnInit, OnDestroy {
         this.bookingPersistService.selectedItemIndex = this.selectedItemIndex;
         // hearing id is stored in session storage
         this.bookingPersistService.selectedHearingId = this.selectedHearingId;
+        this.returnUrlService.setUrl(`${PageUrls.BookingsList}`);
     }
 
     closeHearingDetails() {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.spec.ts
@@ -135,4 +135,18 @@ describe('BookingsPersistService', () => {
             expect(service.endDate).toBeNull();
         });
     });
+
+    describe('#showSearch', () => {
+        it('should set showSearch when false', () => {
+            const showSearch = false;
+            service.showSearch = showSearch;
+            expect(service.showSearch).toBe(showSearch);
+        });
+
+        it('should set showSearch when true', () => {
+            const showSearch = true;
+            service.showSearch = showSearch;
+            expect(service.showSearch).toBe(showSearch);
+        });
+    });
 });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.ts
@@ -15,6 +15,7 @@ export class BookingPersistService {
     private _startDate: Date;
     private _endDate: Date;
     private _participantLastName: string;
+    private _showSearch: boolean;
     private readonly SelectedHearingIdKey = 'SelectedHearingIdKey';
 
     resetAll() {
@@ -160,5 +161,13 @@ export class BookingPersistService {
 
     get selectedHearingId() {
         return sessionStorage.getItem(this.SelectedHearingIdKey);
+    }
+
+    get showSearch(): boolean {
+        return this._showSearch;
+    }
+
+    set showSearch(value) {
+        this._showSearch = value;
     }
 }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.ts
@@ -15,7 +15,7 @@ export class BookingPersistService {
     private _startDate: Date;
     private _endDate: Date;
     private _participantLastName: string;
-    private _showSearch: boolean = false;
+    private _showSearch = false;
     private readonly SelectedHearingIdKey = 'SelectedHearingIdKey';
 
     resetAll() {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.ts
@@ -15,7 +15,7 @@ export class BookingPersistService {
     private _startDate: Date;
     private _endDate: Date;
     private _participantLastName: string;
-    private _showSearch: boolean;
+    private _showSearch: boolean = false;
     private readonly SelectedHearingIdKey = 'SelectedHearingIdKey';
 
     resetAll() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8923


### Change description ###
Fixes an issue where clicking the Back button on the booking details page sometimes takes you back to the dashboard instead of the booking list.

The main culprit is the url used by the returnUrlService. If this isn't set by the calling code, then it defaults to '~/' (the dashboard).

Also fixes the following:

- Start and end dates not persisting after clicking the Back button
- Search form open/close state not persisting after clicking the Back button


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
