### PR TITLE
VIH-9186 Allow participant with similar email to another user to be added

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.spec.ts
@@ -308,7 +308,24 @@ describe('SearchEmailComponent', () => {
         expect(component.notFoundParticipant).toBeFalsy();
         expect(component.emailChanged.emit).toHaveBeenCalled();
     });
+    it('should emit event email is changed if searched email does not exist in non-empty results', () => {
+        const existingParticipant = new ParticipantModel({
+            email: 'YOSXJDKSD@hmcts.net',
+            first_name: 'YOSXJDKSD',
+            last_name: 'YOSXJDKSD'
+        });
 
+        const existingParticipants: ParticipantModel[] = [];
+        existingParticipants.push(existingParticipant);
+
+        component.results = existingParticipants;
+        component.email = 'sd@hmcts.net';
+        spyOn(component.emailChanged, 'emit');
+        component.blurEmail();
+        fixture.detectChanges();
+
+        expect(component.emailChanged.emit).toHaveBeenCalled();
+    });
     it('should find data and set notFoundParticipant to false', () => {
         component.setData(participantList);
         expect(component.results).toEqual(participantList);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.ts
@@ -170,7 +170,7 @@ export class SearchEmailComponent implements OnInit, OnDestroy {
     }
 
     blurEmail() {
-        let userAlreadyExists = this.results && this.results.find(p => p.email === this.email) ? true : false;
+        const userAlreadyExists = this.results && this.results.find(p => p.email === this.email) ? true : false;
 
         if (!this.results || this.results.length === 0 || !userAlreadyExists) {
             this.validateEmail();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.ts
@@ -170,7 +170,9 @@ export class SearchEmailComponent implements OnInit, OnDestroy {
     }
 
     blurEmail() {
-        if (!this.results || this.results.length === 0) {
+        let userAlreadyExists = this.results && this.results.find(p => p.email === this.email) ? true : false;
+
+        if (!this.results || this.results.length === 0 || !userAlreadyExists) {
             this.validateEmail();
             this.emailChanged.emit(this.email);
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9186


### Change description ###
As part of the bug fix we are reinstating the fuzzy map search for participants (searching them using Contains instead of StartsWith), however this reintroduces a bug seen previously (VIH-8952) where a participant cannot be added to a booking if they have a similar email address to another existing user in the search results.

To get round this, we allow the email address to be validated if the email doesn't exist in the search results. If the email is valid then the Add Participant button will then be available once the rest of the form has been populated.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
