### PR TITLE
VIH-9186 Fix issue with invalid email warning being shown after selecting an existing email

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.spec.ts
@@ -320,11 +320,31 @@ describe('SearchEmailComponent', () => {
 
         component.results = existingParticipants;
         component.email = 'sd@hmcts.net';
+        component.invalidPattern = '@hearings.reform.hmcts.net';
         spyOn(component.emailChanged, 'emit');
         component.blurEmail();
         fixture.detectChanges();
 
         expect(component.emailChanged.emit).toHaveBeenCalled();
+    });
+    it('should not emit event email is changed if searched email is invalid and does not exist in non-empty results', () => {
+        const existingParticipant = new ParticipantModel({
+            email: 'YOSXJDKSD@hmcts.net',
+            first_name: 'YOSXJDKSD',
+            last_name: 'YOSXJDKSD'
+        });
+
+        const existingParticipants: ParticipantModel[] = [];
+        existingParticipants.push(existingParticipant);
+
+        component.results = existingParticipants;
+        component.email = 'sds';
+        component.invalidPattern = '@hearings.reform.hmcts.net';
+        spyOn(component.emailChanged, 'emit');
+        component.blurEmail();
+        fixture.detectChanges();
+
+        expect(component.emailChanged.emit).toHaveBeenCalledTimes(0);
     });
     it('should find data and set notFoundParticipant to false', () => {
         component.setData(participantList);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.ts
@@ -151,12 +151,17 @@ export class SearchEmailComponent implements OnInit, OnDestroy {
     }
 
     validateEmail() {
-        const pattern = Constants.EmailPattern;
-        this.isValidEmail = this.email && this.email.length > 2 && this.email.length < 256 && pattern.test(this.email);
-        if (!this.isJudge) {
-            this.isValidEmail = this.isValidEmail && this.email.indexOf(this.invalidPattern) < 0;
-        }
+        this.isValidEmail = this.emailIsValid();
         return this.isValidEmail;
+    }
+
+    emailIsValid() {
+        const pattern = Constants.EmailPattern;
+        let isValidEmail = this.email && this.email.length > 2 && this.email.length < 256 && pattern.test(this.email);
+        if (!this.isJudge) {
+            isValidEmail = isValidEmail && this.email.indexOf(this.invalidPattern) < 0;
+        }
+        return isValidEmail;
     }
 
     blur() {
@@ -171,8 +176,9 @@ export class SearchEmailComponent implements OnInit, OnDestroy {
 
     blurEmail() {
         const userAlreadyExists = this.results && this.results.find(p => p.email === this.email) ? true : false;
+        const emailIsValid = this.emailIsValid();
 
-        if (!this.results || this.results.length === 0 || !userAlreadyExists) {
+        if (!this.results || this.results.length === 0 || (emailIsValid && !userAlreadyExists)) {
             this.validateEmail();
             this.emailChanged.emit(this.email);
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9186


### Change description ###
Fixes an issue introduced by the previous commit, where an "invalid email" warning is shown after selecting an existing email address when creating a booking.

We only want to trigger this.validateEmail() when creating a new user. We include an additional AND condition for emailIsValid to prevent it from triggering prematurely when searching for users.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
