### PR TITLE
VIH-9227 Users get "signed out" error whenever they edit a hearing

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.spec.ts
@@ -509,6 +509,15 @@ describe('SummaryComponent  with existing request', () => {
         fixture = TestBed.createComponent(SummaryComponent);
         component = fixture.componentInstance;
         fixture.detectChanges();
+        const mockSessionStorage = {
+            getItem: (key: string): string => {
+                return 'true';
+            },
+            setItem: (key: string, value: string) => {},
+            removeItem: (key: string) => {},
+            clear: () => {}
+        };
+        spyOn(sessionStorage, 'setItem').and.callFake(mockSessionStorage.setItem);
     });
 
     it('should indicate that the current booking is existing booking', () => {
@@ -550,6 +559,7 @@ describe('SummaryComponent  with existing request', () => {
         expect(component.bookingsSaving).toBeTruthy();
         expect(component.showWaitSaving).toBeFalsy();
         expect(routerSpy.navigate).toHaveBeenCalled();
+        expect(sessionStorage.setItem).toHaveBeenCalled();
 
         expect(videoHearingsServiceSpy.updateHearing).toHaveBeenCalled();
     });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
@@ -330,6 +330,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
                         this.setError(`Failed to book new hearing for ${hearingDetailsResponse.created_by} `);
                         return;
                     }
+                    sessionStorage.setItem(this.newHearingSessionKey, hearingDetailsResponse.id);
                     this.router.navigate([PageUrls.BookingConfirmation]);
                 },
                 error => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9227


### Change description ###
Fixes a UI error upon updating a booking.

The booking confirmation page that they are redirected to looks for a value in session storage - this was not being populated upon updating a booking.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
