### PR TITLE
VIH-9489 Editing work hours - require both start and end time to be populated or empty

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.html
@@ -13,25 +13,25 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <tr class="govuk-table__row" *ngFor="let day of workHours; index as i">
-      <td
-        [ngClass]="{ 'govuk-form-group--error': workHoursEndTimeBeforeStartTimeErrors.includes(i) }"
-        class="govuk-table__cell govuk-!-padding-left-2"
-      >
+    <tr class="govuk-table__row" *ngFor="let day of workHours">
+      <td [ngClass]="{ 'govuk-form-group--error': !workHourIsValid(day.day_of_week_id) }" class="govuk-table__cell govuk-!-padding-left-2">
         {{ day.day_of_week }}
       </td>
       <td class="govuk-table__cell">
-        <input [disabled]="!isEditing" type="time" (blur)="validateTimes(day)" [(ngModel)]="day.start_time" />
+        <input [disabled]="!isEditing" type="time" (blur)="onWorkHourFieldBlur(day)" [(ngModel)]="day.start_time" />
       </td>
       <td class="govuk-table__cell">
-        <input [disabled]="!isEditing" type="time" (blur)="validateTimes(day)" [(ngModel)]="day.end_time" />
+        <input [disabled]="!isEditing" type="time" (blur)="onWorkHourFieldBlur(day)" [(ngModel)]="day.end_time" />
       </td>
     </tr>
   </tbody>
-  <div *ngIf="workHoursEndTimeBeforeStartTimeErrors.length > 0">
-    <p class="govuk-error-message">Error: End Time cannot be before Start Time</p>
-  </div>
 </table>
+<div *ngIf="validationSummary.length > 0">
+  <p class="govuk-error-message">Error:</p>
+  <div *ngFor="let error of validationSummary">
+    <p class="govuk-error-message">{{ error }}</p>
+  </div>
+</div>
 <button
   *ngIf="!isEditing; else editingButtonsBlock"
   id="edit-individual-work-hours-button"
@@ -48,7 +48,7 @@
       class="govuk-button govuk-!-margin-right-6"
       data-module="govuk-button"
       (click)="saveWorkingHours()"
-      [disabled]="workHoursEndTimeBeforeStartTimeErrors.length > 0"
+      [disabled]="validationFailures.length > 0"
     >
       Save
     </button>

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.spec.ts
@@ -249,6 +249,7 @@ describe('VhoWorkHoursTableComponent', () => {
             validationFailure.id = 1;
             validationFailure.errorMessage = VhoWorkHoursTableComponent.ErrorEndTimeBeforeStartTime;
             component.validationFailures = [validationFailure];
+            component.validationSummary = [VhoWorkHoursTableComponent.ErrorEndTimeBeforeStartTime];
 
             const workHourDay = new VhoWorkHoursResponse({
                 day_of_week_id: 1,
@@ -297,6 +298,7 @@ describe('VhoWorkHoursTableComponent', () => {
             validationFailure.id = 1;
             validationFailure.errorMessage = VhoWorkHoursTableComponent.ErrorStartAndEndTimeBothRequired;
             component.validationFailures = [validationFailure];
+            component.validationSummary = [VhoWorkHoursTableComponent.ErrorStartAndEndTimeBothRequired];
 
             const workHourDay = new VhoWorkHoursResponse({
                 day_of_week_id: 1,

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { VhoWorkHoursTableComponent } from './vho-work-hours-table.component';
+import { ValidationFailure, VhoWorkHoursTableComponent } from './vho-work-hours-table.component';
 import { BHClient, VhoNonAvailabilityWorkHoursResponse, VhoWorkHoursResponse } from '../../../services/clients/api-client';
 import { Logger } from '../../../services/logger';
 import { VideoHearingsService } from '../../../services/video-hearings.service';
@@ -72,7 +72,10 @@ describe('VhoWorkHoursTableComponent', () => {
 
         it('should disable save button when errors exist', () => {
             component.isEditing = true;
-            component.workHoursEndTimeBeforeStartTimeErrors = [0];
+            const validationFailure = new ValidationFailure();
+            validationFailure.id = 1;
+            validationFailure.errorMessage = 'Error';
+            component.validationFailures = [validationFailure];
             fixture.detectChanges();
 
             const saveButton = fixture.debugElement.query(By.css('#save-individual-work-hours-button')).nativeElement;
@@ -106,7 +109,7 @@ describe('VhoWorkHoursTableComponent', () => {
 
             component.cancelEditingWorkingHours();
 
-            expect(component.workHoursEndTimeBeforeStartTimeErrors.length).toBe(0);
+            expect(component.validationFailures.length).toBe(0);
         });
 
         it('should set work hours back to original values', () => {
@@ -164,7 +167,7 @@ describe('VhoWorkHoursTableComponent', () => {
             component.saveWorkingHours();
 
             expect(component.isEditing).toBe(false);
-            expect(component.workHoursEndTimeBeforeStartTimeErrors.length).toBe(0);
+            expect(component.validationFailures.length).toBe(0);
         });
     });
 
@@ -220,6 +223,11 @@ describe('VhoWorkHoursTableComponent', () => {
     });
 
     describe('validateTimes', () => {
+        beforeEach(() => {
+            component.validationFailures = [];
+            component.validationSummary = [];
+        });
+
         it('should add end time before start time error', () => {
             const workHourDay = new VhoWorkHoursResponse({
                 day_of_week_id: 1,
@@ -229,12 +237,18 @@ describe('VhoWorkHoursTableComponent', () => {
 
             component.validateTimes(workHourDay);
 
-            expect(component.workHoursEndTimeBeforeStartTimeErrors.length).toBe(1);
-            expect(component.workHoursEndTimeBeforeStartTimeErrors[0]).toBe(0);
+            expect(component.validationFailures.length).toBe(1);
+            expect(component.validationFailures[0].id).toBe(1);
+            expect(component.validationFailures[0].errorMessage).toBe(VhoWorkHoursTableComponent.ErrorEndTimeBeforeStartTime);
+            expect(component.validationSummary.length).toBe(1);
+            expect(component.validationSummary[0]).toBe(VhoWorkHoursTableComponent.ErrorEndTimeBeforeStartTime);
         });
 
         it('should remove end time before start time error when fixed', () => {
-            component.workHoursEndTimeBeforeStartTimeErrors = [0];
+            const validationFailure = new ValidationFailure();
+            validationFailure.id = 1;
+            validationFailure.errorMessage = VhoWorkHoursTableComponent.ErrorEndTimeBeforeStartTime;
+            component.validationFailures = [validationFailure];
 
             const workHourDay = new VhoWorkHoursResponse({
                 day_of_week_id: 1,
@@ -244,7 +258,92 @@ describe('VhoWorkHoursTableComponent', () => {
 
             component.validateTimes(workHourDay);
 
-            expect(component.workHoursEndTimeBeforeStartTimeErrors.length).toBe(0);
+            expect(component.validationFailures.length).toBe(0);
+            expect(component.validationSummary.length).toBe(0);
+        });
+
+        it('should add start and end time both required error when start time is empty', () => {
+            const workHourDay = new VhoWorkHoursResponse({
+                day_of_week_id: 1,
+                end_time: '09:00'
+            });
+
+            component.validateTimes(workHourDay);
+
+            expect(component.validationFailures.length).toBe(1);
+            expect(component.validationFailures[0].id).toBe(1);
+            expect(component.validationFailures[0].errorMessage).toBe(VhoWorkHoursTableComponent.ErrorStartAndEndTimeBothRequired);
+            expect(component.validationSummary.length).toBe(1);
+            expect(component.validationSummary[0]).toBe(VhoWorkHoursTableComponent.ErrorStartAndEndTimeBothRequired);
+        });
+
+        it('should add start and end time both required error when end time is empty', () => {
+            const workHourDay = new VhoWorkHoursResponse({
+                day_of_week_id: 1,
+                start_time: '09:00'
+            });
+
+            component.validateTimes(workHourDay);
+
+            expect(component.validationFailures.length).toBe(1);
+            expect(component.validationFailures[0].id).toBe(1);
+            expect(component.validationFailures[0].errorMessage).toBe(VhoWorkHoursTableComponent.ErrorStartAndEndTimeBothRequired);
+            expect(component.validationSummary.length).toBe(1);
+            expect(component.validationSummary[0]).toBe(VhoWorkHoursTableComponent.ErrorStartAndEndTimeBothRequired);
+        });
+
+        it('should remove start and end time both required error when fixed', () => {
+            const validationFailure = new ValidationFailure();
+            validationFailure.id = 1;
+            validationFailure.errorMessage = VhoWorkHoursTableComponent.ErrorStartAndEndTimeBothRequired;
+            component.validationFailures = [validationFailure];
+
+            const workHourDay = new VhoWorkHoursResponse({
+                day_of_week_id: 1,
+                end_time: '12:00',
+                start_time: '09:00'
+            });
+
+            component.validateTimes(workHourDay);
+
+            expect(component.validationFailures.length).toBe(0);
+            expect(component.validationSummary.length).toBe(0);
+        });
+    });
+
+    describe('workHourIsValid', () => {
+        it('should return true when work hour is valid', () => {
+            const workHour = new VhoWorkHoursResponse({
+                day_of_week_id: 1,
+                start_time: '09:00',
+                end_time: '12:00'
+            });
+            component.validateTimes(workHour);
+            const result = component.workHourIsValid(workHour.day_of_week_id);
+            expect(result).toBe(true);
+        });
+
+        it('should return false when work hour is not valid', () => {
+            const workHour = new VhoWorkHoursResponse({
+                day_of_week_id: 1,
+                start_time: '09:00'
+            });
+            component.validateTimes(workHour);
+            const result = component.workHourIsValid(workHour.day_of_week_id);
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('onWorkHourFieldBlur', () => {
+        it('should validate', () => {
+            const workHour = new VhoWorkHoursResponse({
+                day_of_week_id: 1,
+                start_time: '09:00'
+            });
+            component.onWorkHourFieldBlur(workHour);
+            const result = component.workHourIsValid(workHour.day_of_week_id);
+            expect(result).toBe(false);
+            expect(videoServiceSpy.setVhoNonAvailabiltiesHaveChanged).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.ts
@@ -24,7 +24,7 @@ export class VhoWorkHoursTableComponent implements CanDeactiveComponent {
         }
     }
 
-    public static readonly ErrorStartAndEndTimeBothRequired = 'Both Start Time and End Time must be populated or empty';
+    public static readonly ErrorStartAndEndTimeBothRequired = 'Both Start Time and End Time must be filled in or empty';
     public static readonly ErrorEndTimeBeforeStartTime = 'End Time cannot be before Start Time';
     workHours: VhoWorkHoursResponse[] = [];
     validationFailures: ValidationFailure[] = [];

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.ts
@@ -4,6 +4,11 @@ import { CanDeactiveComponent } from '../../../common/guards/changes.guard';
 import { Observable } from 'rxjs';
 import { VideoHearingsService } from '../../../services/video-hearings.service';
 
+export class ValidationFailure {
+    id: number;
+    errorMessage: string;
+}
+
 @Component({
     selector: 'app-vho-work-hours-table',
     templateUrl: './vho-work-hours-table.component.html'
@@ -19,8 +24,11 @@ export class VhoWorkHoursTableComponent implements CanDeactiveComponent {
         }
     }
 
+    public static readonly ErrorStartAndEndTimeBothRequired = 'Both Start Time and End Time must be populated or empty';
+    public static readonly ErrorEndTimeBeforeStartTime = 'End Time cannot be before Start Time';
     workHours: VhoWorkHoursResponse[] = [];
-    workHoursEndTimeBeforeStartTimeErrors: number[] = [];
+    validationFailures: ValidationFailure[] = [];
+    validationSummary: string[] = [];
     originalWorkHours: VhoWorkHoursResponse[] = [];
     isEditing = false;
     showSaveConfirmation = false;
@@ -38,14 +46,16 @@ export class VhoWorkHoursTableComponent implements CanDeactiveComponent {
 
     cancelEditingWorkingHours() {
         this.isEditing = false;
-        this.workHoursEndTimeBeforeStartTimeErrors = [];
+        this.validationFailures = [];
+        this.validationSummary = [];
         this.workHours = this.originalWorkHours;
         this.videoHearingsService.cancelVhoNonAvailabiltiesRequest();
     }
 
     saveWorkingHours() {
         this.saveWorkHours.emit(this.workHours);
-        this.workHoursEndTimeBeforeStartTimeErrors = [];
+        this.validationFailures = [];
+        this.validationSummary = [];
         this.isEditing = false;
         this.videoHearingsService.cancelVhoNonAvailabiltiesRequest();
     }
@@ -61,7 +71,14 @@ export class VhoWorkHoursTableComponent implements CanDeactiveComponent {
     }
 
     validateTimes(day: VhoWorkHoursResponse) {
-        if (!day.start_time || !day.end_time) {
+        let error = VhoWorkHoursTableComponent.ErrorStartAndEndTimeBothRequired;
+        if ((day.start_time && !day.end_time) || (!day.start_time && day.end_time)) {
+            this.addValidationError(day.day_of_week_id, error);
+            return;
+        }
+        this.removeValidationError(day.day_of_week_id, error);
+
+        if (!day.start_time && !day.end_time) {
             return;
         }
 
@@ -77,15 +94,55 @@ export class VhoWorkHoursTableComponent implements CanDeactiveComponent {
         endDate.setHours(parseInt(workHourArray[0], 10));
         endDate.setMinutes(parseInt(workHourArray[1], 10));
 
+        error = VhoWorkHoursTableComponent.ErrorEndTimeBeforeStartTime;
         if (endDate <= startDate) {
-            this.workHoursEndTimeBeforeStartTimeErrors.push(day.day_of_week_id - 1);
-        } else {
-            const index = this.workHoursEndTimeBeforeStartTimeErrors.findIndex(x => x === day.day_of_week_id - 1);
+            this.addValidationError(day.day_of_week_id, error);
+            return;
+        }
+        this.removeValidationError(day.day_of_week_id, error);
+    }
 
-            if (index > -1) {
-                this.workHoursEndTimeBeforeStartTimeErrors.splice(index, 1);
+    addValidationError(dayOfWeekId: number, error: string) {
+        const existingValidationFailureIndex = this.validationFailures.findIndex(x => x.id === dayOfWeekId && x.errorMessage === error);
+        const existingValidationSummaryIndex = this.validationSummary.findIndex(x => x === error);
+
+        if (existingValidationFailureIndex === -1) {
+            this.validationFailures.push({
+                id: dayOfWeekId,
+                errorMessage: error
+            });
+        }
+
+        if (existingValidationSummaryIndex === -1) {
+            this.validationSummary.push(error);
+        }
+    }
+
+    removeValidationError(dayOfWeekId: number, error: string) {
+        const existingValidationFailureIndex = this.validationFailures.findIndex(x => x.id === dayOfWeekId && x.errorMessage === error);
+        const existingValidationSummaryIndex = this.validationSummary.findIndex(x => x === error);
+
+        if (existingValidationFailureIndex !== -1) {
+            this.validationFailures.splice(existingValidationFailureIndex, 1);
+        }
+
+        if (existingValidationSummaryIndex !== -1) {
+            if (!this.validationFailures.some(x => x.errorMessage === error)) {
+                this.validationSummary.splice(existingValidationSummaryIndex, 1);
             }
         }
+    }
+
+    workHourIsValid(dayOfWeekId: number) {
+        if (this.validationFailures.some(x => x.id === dayOfWeekId)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    onWorkHourFieldBlur(workHour: VhoWorkHoursResponse) {
+        this.validateTimes(workHour);
         this.registerUnsavedChanges();
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9489


### Change description ###
Adds missing frontend validation for requiring both start and end time to be either populated or empty when editing work hours.

Includes some refactoring so that the form can support multiple validation errors


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
