### PR TITLE
VIH-9488 Hide save work hours confirmation message when clicking edit or cancel

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/edit-work-hours.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/edit-work-hours.component.html
@@ -10,7 +10,13 @@
       (dataChange)="dataChanged($event)"
       [dataChangedBroadcast]="dataChangedBroadcast"
     ></app-vho-search>
-    <app-vho-work-hours-table *ngIf="showWorkHoursTable" (saveWorkHours)="onSaveWorkHours($event)" [result]="result">
+    <app-vho-work-hours-table
+      *ngIf="showWorkHoursTable"
+      (saveWorkHours)="onSaveWorkHours($event)"
+      [result]="result"
+      (editWorkHours)="onEditWorkHours()"
+      (cancelSaveWorkHours)="onCancelSaveWorkHours()"
+    >
     </app-vho-work-hours-table>
     <app-vho-work-hours-non-availability-table
       *ngIf="showNonWorkHoursTable"

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/edit-work-hours.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/edit-work-hours.component.spec.ts
@@ -308,6 +308,26 @@ describe('EditWorkHoursComponent', () => {
         });
     });
 
+    describe('onEditWorkHours', () => {
+        it('should clear update working hour confirmation messages', () => {
+            component.isUploadWorkHoursFailure = true;
+            component.isUploadWorkHoursSuccessful = true;
+            component.onEditWorkHours();
+
+            assertConfirmationMessagesForSaveWorkHoursAreCleared();
+        });
+    });
+
+    describe('onCancelSaveWorkHours', () => {
+        it('should clear update working hour confirmation messages', () => {
+            component.isUploadWorkHoursFailure = true;
+            component.isUploadWorkHoursSuccessful = true;
+            component.onCancelSaveWorkHours();
+
+            assertConfirmationMessagesForSaveWorkHoursAreCleared();
+        });
+    });
+
     describe('dataChange', () => {
         it('should clear update non-working hour confirmation messages', () => {
             component.dataChanged(true);
@@ -319,5 +339,10 @@ describe('EditWorkHoursComponent', () => {
     function assertConfirmationMessagesForSaveNonWorkHoursAreCleared() {
         expect(component.showSaveNonWorkHoursFailedPopup).toBe(false);
         expect(component.isUploadNonWorkHoursSuccessful).toBe(false);
+    }
+
+    function assertConfirmationMessagesForSaveWorkHoursAreCleared() {
+        expect(component.isUploadWorkHoursFailure).toBe(false);
+        expect(component.isUploadWorkHoursSuccessful).toBe(false);
     }
 });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/edit-work-hours.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/edit-work-hours.component.ts
@@ -111,6 +111,7 @@ export class EditWorkHoursComponent implements OnInit {
         }
 
         this.clearConfirmationMessagesForSaveNonWorkHours();
+        this.clearConfirmationMessagesForSaveWorkHours();
     }
 
     setHoursType($event: HoursType) {
@@ -175,9 +176,22 @@ export class EditWorkHoursComponent implements OnInit {
         this.clearConfirmationMessagesForSaveNonWorkHours();
     }
 
+    onEditWorkHours() {
+        this.clearConfirmationMessagesForSaveWorkHours();
+    }
+
+    onCancelSaveWorkHours() {
+        this.clearConfirmationMessagesForSaveWorkHours();
+    }
+
     clearConfirmationMessagesForSaveNonWorkHours() {
         this.showSaveNonWorkHoursFailedPopup = false;
         this.isUploadNonWorkHoursSuccessful = false;
+    }
+
+    clearConfirmationMessagesForSaveWorkHours() {
+        this.isUploadWorkHoursFailure = false;
+        this.isUploadWorkHoursSuccessful = false;
     }
 
     dataChanged($event: boolean) {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.spec.ts
@@ -112,6 +112,15 @@ describe('VhoWorkHoursTableComponent', () => {
             expect(component.validationFailures.length).toBe(0);
         });
 
+        it('should emit event', () => {
+            component.isEditing = true;
+            spyOn(component.cancelSaveWorkHours, 'emit');
+
+            component.cancelEditingWorkingHours();
+
+            expect(component.cancelSaveWorkHours.emit).toHaveBeenCalledTimes(1);
+        });
+
         it('should set work hours back to original values', () => {
             const originalMondayWorkHours = new VhoWorkHoursResponse();
             originalMondayWorkHours.day_of_week_id = 1;
@@ -201,6 +210,20 @@ describe('VhoWorkHoursTableComponent', () => {
             component.switchToEditMode();
 
             expect(JSON.stringify(component.originalWorkHours)).toEqual(JSON.stringify(component.workHours));
+        });
+
+        it('should emit event when work hours are not empty', () => {
+            const mondayWorkHours = new VhoWorkHoursResponse();
+            mondayWorkHours.day_of_week_id = 1;
+            mondayWorkHours.end_time = '17:00';
+            mondayWorkHours.start_time = '09:00';
+
+            spyOn(component.editWorkHours, 'emit');
+            component.workHours = [mondayWorkHours];
+
+            component.switchToEditMode();
+
+            expect(component.editWorkHours.emit).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component.ts
@@ -34,6 +34,8 @@ export class VhoWorkHoursTableComponent implements CanDeactiveComponent {
     showSaveConfirmation = false;
 
     @Output() saveWorkHours: EventEmitter<VhoWorkHoursResponse[]> = new EventEmitter();
+    @Output() editWorkHours: EventEmitter<void> = new EventEmitter();
+    @Output() cancelSaveWorkHours: EventEmitter<void> = new EventEmitter();
 
     @HostListener('window:beforeunload', ['$event'])
     canDeactive(): Observable<boolean> | boolean {
@@ -50,6 +52,7 @@ export class VhoWorkHoursTableComponent implements CanDeactiveComponent {
         this.validationSummary = [];
         this.workHours = this.originalWorkHours;
         this.videoHearingsService.cancelVhoNonAvailabiltiesRequest();
+        this.cancelSaveWorkHours.emit();
     }
 
     saveWorkingHours() {
@@ -68,6 +71,7 @@ export class VhoWorkHoursTableComponent implements CanDeactiveComponent {
         this.isEditing = true;
 
         this.originalWorkHours = JSON.parse(JSON.stringify(this.workHours));
+        this.editWorkHours.emit();
     }
 
     validateTimes(day: VhoWorkHoursResponse) {

--- a/charts/vh-admin-web/Chart.yaml
+++ b/charts/vh-admin-web/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: vh-admin-web
 home: https://github.com/hmcts/vh-admin-web
-version: 0.0.8
+version: 0.0.9
 description: Helm Chart for Admin Web
 maintainers:
   - name: VH Devops

--- a/charts/vh-admin-web/Chart.yaml
+++ b/charts/vh-admin-web/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: vh-admin-web
 home: https://github.com/hmcts/vh-admin-web
 version: 0.0.8
-description: Helm Chart for test Hearing test-api
+description: Helm Chart for Admin Web
 maintainers:
   - name: VH Devops
   


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9488


### Change description ###
Fixes an issue where the confirmation message for saving work hours is still visible after clicking Edit or Cancel again.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
