### PR TITLE
VIH-9497 Upload (non) working hours not working after fixing validation errors

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/work-allocation.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/work-allocation.component.html
@@ -25,7 +25,9 @@
           <label class="govuk-label govuk-!-font-size-16" for="working-hours-file-upload"> Select .CSV file to upload </label>
           <input
             (change)="handleFileInput($event.target.files[0], 'UploadWorkingHours')"
+            (click)="workingHoursFileUpload.value = null"
             class="govuk-file-upload"
+            #workingHoursFileUpload
             id="working-hours-file-upload"
             name="working-hours-file-upload"
             type="file"
@@ -116,7 +118,9 @@
           <label class="govuk-label govuk-!-font-size-16" for="non-availability-hours-file-upload"> Select .CSV file to upload </label>
           <input
             (change)="handleFileInput($event.target.files[0], 'UploadNonWorkingHours')"
+            (click)="nonWorkingHoursFileUpload.value = null"
             class="govuk-file-upload"
+            #nonWorkingHoursFileUpload
             id="non-availability-hours-file-upload"
             name="non-availability-hours-file-upload"
             type="file"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9497


### Change description ###
Fixes an issue where attempting to re-upload (non) working hours after a failed upload does not work.

The issue is that the file is only processed when the uploaded file path changes, so if you try to re-upload the same file it won't work. Fix by clearing the selected file each time you click the Choose file button.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
