### PR TITLE
VIH-9518 Fix for unsaved changes prompt after saving non-availabilities

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-non-availability-table/vho-work-hours-non-availability-table.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-non-availability-table/vho-work-hours-non-availability-table.component.spec.ts
@@ -1,14 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { BHClient, VhoNonAvailabilityWorkHoursResponse, VhoWorkHoursResponse } from '../../../services/clients/api-client';
+import { BHClient, VhoNonAvailabilityWorkHoursResponse } from '../../../services/clients/api-client';
 import { Logger } from '../../../services/logger';
 import { ConfirmDeleteHoursPopupComponent } from '../../../popups/confirm-delete-popup/confirm-delete-popup.component';
-import { of, throwError } from 'rxjs';
+import { of, throwError, Subject } from 'rxjs';
 import { DatePipe } from '@angular/common';
 import { ValidationFailure, VhoWorkHoursNonAvailabilityTableComponent } from './vho-work-hours-non-availability-table.component';
 import { EditVhoNonAvailabilityWorkHoursModel } from '../edit-non-work-hours-model';
-import { Subject } from 'rxjs';
 import { By } from '@angular/platform-browser';
-import { HoursType } from '../../../common/model/hours-type';
 import { FormBuilder } from '@angular/forms';
 import { VideoHearingsService } from '../../../services/video-hearings.service';
 
@@ -43,6 +41,7 @@ describe('VhoNonAvailabilityWorkHoursTableComponent', () => {
         fixture = TestBed.createComponent(VhoWorkHoursNonAvailabilityTableComponent);
         component = fixture.componentInstance;
         component.saveNonWorkHoursCompleted$ = new Subject<boolean>();
+        videoServiceSpy.cancelVhoNonAvailabiltiesRequest.calls.reset();
         fixture.detectChanges();
     });
 
@@ -227,7 +226,7 @@ describe('VhoNonAvailabilityWorkHoursTableComponent', () => {
         });
 
         describe('save button clicked', () => {
-            it('should emit save event', () => {
+            it('should save correctly', () => {
                 component.switchToEditMode();
                 fixture.detectChanges();
                 spyOn(component.saveNonWorkHours, 'emit');
@@ -239,6 +238,7 @@ describe('VhoNonAvailabilityWorkHoursTableComponent', () => {
                 expect(component.isSaving).toBe(true);
                 expect(component.saveNonWorkHours.emit).toHaveBeenCalledTimes(1);
                 expect(component.saveNonWorkHours.emit).toHaveBeenCalledWith(component.nonWorkHours);
+                expect(videoServiceSpy.cancelVhoNonAvailabiltiesRequest).toHaveBeenCalledTimes(1);
             });
         });
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-non-availability-table/vho-work-hours-non-availability-table.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/edit-work-hours/vho-work-hours-non-availability-table/vho-work-hours-non-availability-table.component.ts
@@ -115,6 +115,7 @@ export class VhoWorkHoursNonAvailabilityTableComponent implements OnInit, CanDea
         this.nonWorkHours.forEach(slot => {
             slot.new_row = false;
         });
+        this.videoHearingsService.cancelVhoNonAvailabiltiesRequest();
     }
 
     cancelEditingNonWorkingHours() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9518


### Change description ###

- Fix an issue where a warning is shown about unsaved changes after saving non-availabilities and navigating away
- Tidy up imports


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
