### PR TITLE
VIH-9621 Store user profile in property instead of session

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
@@ -54,8 +54,5 @@ export const Constants = {
         Observer: 'Observer',
         Interpreter: 'Interpreter'
     },
-    OtherParticipantRoles: ['Staff Member', 'Observer', 'Panel Member', 'Winger'],
-    SessionStorageKeys: {
-        userProfile: 'userProfile'
-    }
+    OtherParticipantRoles: ['Staff Member', 'Observer', 'Panel Member', 'Winger']
 };

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/security/logout.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/security/logout.component.spec.ts
@@ -1,0 +1,41 @@
+import { fakeAsync, flush } from "@angular/core/testing";
+import { OidcSecurityService } from "angular-auth-oidc-client";
+import { Subject } from "rxjs";
+import { UserIdentityService } from "../services/user-identity.service";
+import { LogoutComponent } from "./logout.component";
+
+describe('LogoutComponent', () => {
+    let component: LogoutComponent;
+    let userIdentityServiceSpy: jasmine.SpyObj<UserIdentityService>;
+    let securityServiceSpy;
+
+    beforeAll(() => {
+        securityServiceSpy = jasmine.createSpyObj<OidcSecurityService>('OidcSecurityService', ['logoffAndRevokeTokens', 'isAuthenticated$'])
+        userIdentityServiceSpy = jasmine.createSpyObj<UserIdentityService>('UserIdentityService', ['clearUserProfile']);
+    });
+
+    beforeEach(() => {
+        securityServiceSpy.isAuthenticated$ = new Subject<boolean>();
+        userIdentityServiceSpy.clearUserProfile.calls.reset();
+        securityServiceSpy.logoffAndRevokeTokens.calls.reset();
+
+        component = new LogoutComponent(securityServiceSpy, userIdentityServiceSpy);
+    });
+
+    it('should call logout if authenticated', fakeAsync(() => {
+        component.ngOnInit();
+        securityServiceSpy.isAuthenticated$.next(true);
+
+        expect(userIdentityServiceSpy.clearUserProfile).toHaveBeenCalled();
+        expect(securityServiceSpy.logoffAndRevokeTokens).toHaveBeenCalled();
+    }));
+
+    it('should not call logout if unauthenticated', fakeAsync(() => {
+        component.ngOnInit();
+        securityServiceSpy.isAuthenticated$.next(false);
+
+        expect(userIdentityServiceSpy.clearUserProfile).toHaveBeenCalledTimes(0);
+        expect(securityServiceSpy.logoffAndRevokeTokens).toHaveBeenCalledTimes(0);
+    }));
+});
+

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/security/logout.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/security/logout.component.spec.ts
@@ -1,8 +1,8 @@
-import { fakeAsync, flush } from "@angular/core/testing";
-import { OidcSecurityService } from "angular-auth-oidc-client";
-import { Subject } from "rxjs";
-import { UserIdentityService } from "../services/user-identity.service";
-import { LogoutComponent } from "./logout.component";
+import { fakeAsync } from '@angular/core/testing';
+import { OidcSecurityService } from 'angular-auth-oidc-client';
+import { Subject } from 'rxjs';
+import { UserIdentityService } from '../services/user-identity.service';
+import { LogoutComponent } from './logout.component';
 
 describe('LogoutComponent', () => {
     let component: LogoutComponent;
@@ -10,7 +10,10 @@ describe('LogoutComponent', () => {
     let securityServiceSpy;
 
     beforeAll(() => {
-        securityServiceSpy = jasmine.createSpyObj<OidcSecurityService>('OidcSecurityService', ['logoffAndRevokeTokens', 'isAuthenticated$'])
+        securityServiceSpy = jasmine.createSpyObj<OidcSecurityService>('OidcSecurityService', [
+            'logoffAndRevokeTokens',
+            'isAuthenticated$'
+        ]);
         userIdentityServiceSpy = jasmine.createSpyObj<UserIdentityService>('UserIdentityService', ['clearUserProfile']);
     });
 
@@ -38,4 +41,3 @@ describe('LogoutComponent', () => {
         expect(securityServiceSpy.logoffAndRevokeTokens).toHaveBeenCalledTimes(0);
     }));
 });
-

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/security/logout.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/security/logout.component.ts
@@ -1,5 +1,6 @@
 import { OnInit, Component, Injectable } from '@angular/core';
 import { OidcSecurityService } from 'angular-auth-oidc-client';
+import { UserIdentityService } from '../services/user-identity.service';
 
 @Component({
     selector: 'app-logout',
@@ -7,11 +8,12 @@ import { OidcSecurityService } from 'angular-auth-oidc-client';
 })
 @Injectable()
 export class LogoutComponent implements OnInit {
-    constructor(private oidcSecurityService: OidcSecurityService) {}
+    constructor(private oidcSecurityService: OidcSecurityService, private userIdentityService: UserIdentityService) {}
 
     ngOnInit() {
         this.oidcSecurityService.isAuthenticated$.subscribe(auth => {
             if (auth) {
+                this.userIdentityService.clearUserProfile();
                 this.oidcSecurityService.logoffAndRevokeTokens();
             }
         });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/user-identity.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/user-identity.service.spec.ts
@@ -14,10 +14,6 @@ describe('UserIdentityService', () => {
         });
     });
 
-    afterEach(() => {
-        sessionStorage.clear();
-    });
-
     it('should retrieve user profile from memory when it exists', inject([UserIdentityService], (service: UserIdentityService) => {
         const userProfile = new UserProfileResponse({
             is_case_administrator: false,

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/user-identity.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/user-identity.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { UserIdentityService } from './user-identity.service';
 import { HttpClientModule } from '@angular/common/http';
-import { Constants } from '../common/constants';
 import { BHClient, UserProfileResponse } from './clients/api-client';
 import { of } from 'rxjs';
 
@@ -26,7 +25,7 @@ describe('UserIdentityService', () => {
             is_vh_team_leader: true
         });
 
-        sessionStorage.setItem(Constants.SessionStorageKeys.userProfile, JSON.stringify(userProfile));
+        service.profile = userProfile;
 
         service.getUserInformation().subscribe(result => {
             expect(result.is_case_administrator).toEqual(userProfile.is_case_administrator);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/user-identity.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/user-identity.service.spec.ts
@@ -18,7 +18,7 @@ describe('UserIdentityService', () => {
         sessionStorage.clear();
     });
 
-    it('should retrieve user profile from session storage when it exists', inject([UserIdentityService], (service: UserIdentityService) => {
+    it('should retrieve user profile from memory when it exists', inject([UserIdentityService], (service: UserIdentityService) => {
         const userProfile = new UserProfileResponse({
             is_case_administrator: false,
             is_vh_officer_administrator_role: true,
@@ -34,7 +34,7 @@ describe('UserIdentityService', () => {
         });
     }));
 
-    it('should retrieve user profile from api and save to session storage', inject(
+    it('should retrieve user profile from api and save to memory', inject(
         [UserIdentityService],
         (service: UserIdentityService) => {
             const userProfile = new UserProfileResponse({
@@ -50,6 +50,21 @@ describe('UserIdentityService', () => {
                 expect(result.is_vh_officer_administrator_role).toEqual(userProfile.is_vh_officer_administrator_role);
                 expect(result.is_vh_team_leader).toEqual(userProfile.is_vh_team_leader);
             });
+        }
+    ));
+
+    it('should clear set profile', inject(
+        [UserIdentityService],
+        (service: UserIdentityService) => {
+            const userProfile = new UserProfileResponse({
+                is_case_administrator: false,
+                is_vh_officer_administrator_role: true,
+                is_vh_team_leader: true
+            });
+
+            service.profile = userProfile;
+            service.clearUserProfile();
+            expect(service.profile).toBeNull();
         }
     ));
 });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/user-identity.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/user-identity.service.spec.ts
@@ -34,37 +34,31 @@ describe('UserIdentityService', () => {
         });
     }));
 
-    it('should retrieve user profile from api and save to memory', inject(
-        [UserIdentityService],
-        (service: UserIdentityService) => {
-            const userProfile = new UserProfileResponse({
-                is_case_administrator: false,
-                is_vh_officer_administrator_role: true,
-                is_vh_team_leader: true
-            });
+    it('should retrieve user profile from api and save to memory', inject([UserIdentityService], (service: UserIdentityService) => {
+        const userProfile = new UserProfileResponse({
+            is_case_administrator: false,
+            is_vh_officer_administrator_role: true,
+            is_vh_team_leader: true
+        });
 
-            bhClientSpy.getUserProfile.and.returnValue(of(userProfile));
+        bhClientSpy.getUserProfile.and.returnValue(of(userProfile));
 
-            service.getUserInformation().subscribe(result => {
-                expect(result.is_case_administrator).toEqual(userProfile.is_case_administrator);
-                expect(result.is_vh_officer_administrator_role).toEqual(userProfile.is_vh_officer_administrator_role);
-                expect(result.is_vh_team_leader).toEqual(userProfile.is_vh_team_leader);
-            });
-        }
-    ));
+        service.getUserInformation().subscribe(result => {
+            expect(result.is_case_administrator).toEqual(userProfile.is_case_administrator);
+            expect(result.is_vh_officer_administrator_role).toEqual(userProfile.is_vh_officer_administrator_role);
+            expect(result.is_vh_team_leader).toEqual(userProfile.is_vh_team_leader);
+        });
+    }));
 
-    it('should clear set profile', inject(
-        [UserIdentityService],
-        (service: UserIdentityService) => {
-            const userProfile = new UserProfileResponse({
-                is_case_administrator: false,
-                is_vh_officer_administrator_role: true,
-                is_vh_team_leader: true
-            });
+    it('should clear set profile', inject([UserIdentityService], (service: UserIdentityService) => {
+        const userProfile = new UserProfileResponse({
+            is_case_administrator: false,
+            is_vh_officer_administrator_role: true,
+            is_vh_team_leader: true
+        });
 
-            service.profile = userProfile;
-            service.clearUserProfile();
-            expect(service.profile).toBeNull();
-        }
-    ));
+        service.profile = userProfile;
+        service.clearUserProfile();
+        expect(service.profile).toBeNull();
+    }));
 });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/user-identity.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/user-identity.service.ts
@@ -2,28 +2,31 @@
 import { BHClient, UserProfileResponse } from '../services/clients/api-client';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { Constants } from '../common/constants';
 
 @Injectable({
     providedIn: 'root'
 })
 export class UserIdentityService {
+    profile: UserProfileResponse;
+
     constructor(private bhClient: BHClient) {}
 
     getUserInformation(): Observable<UserProfileResponse> {
-        const userProfile = JSON.parse(sessionStorage.getItem(Constants.SessionStorageKeys.userProfile));
-
-        if (userProfile) {
-            return of(userProfile);
+        if (this.profile) {
+            return of(this.profile);
         }
 
         const userProfileResponse = this.bhClient.getUserProfile().pipe(
             map(userProfileFromApi => {
-                sessionStorage.setItem(Constants.SessionStorageKeys.userProfile, JSON.stringify(userProfileFromApi));
-                return userProfileFromApi;
+                this.profile = userProfileFromApi;
+                return this.profile;
             })
         );
 
         return userProfileResponse;
+    }
+
+    clearUserProfile(): void {
+        this.profile = null;
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9621


### Change description ###

- Like Video Web, store the cached user profile in a property rather than the session to prevent users from tampering with their roles
- Add spec.ts for the logout component


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
