### PR TITLE
VIH-9708 404 errors on GetTelephoneConferenceIdById endpoint from Admin web api

### DIFF
--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
@@ -38,7 +38,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _expectedUserIdentityName = "created by";
 
             _mocker = AutoMock.GetLoose();
-            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false))
                 .ReturnsAsync(new ConferenceDetailsResponse
                 {
                     MeetingRoom = new MeetingRoomResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/CancelHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/CancelHearingTests.cs
@@ -26,7 +26,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         public void Setup()
         {
             _mocker = AutoMock.GetLoose();
-            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false))
                 .ReturnsAsync(new ConferenceDetailsResponse
                 {
                     MeetingRoom = new MeetingRoomResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
@@ -78,7 +78,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             _conferencesServiceMock = new Mock<IConferenceDetailsService>();
             _featureToggle = new Mock<IFeatureToggles>();
             _featureToggle.Setup(e => e.BookAndConfirmToggle()).Returns(true);
-            _conferencesServiceMock.Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+            _conferencesServiceMock.Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false))
                 .ReturnsAsync(new ConferenceDetailsResponse
                 {
                     MeetingRoom = new MeetingRoomResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetHearingTests.cs
@@ -1,13 +1,8 @@
-﻿using AdminWebsite.Models;
-using AdminWebsite.Security;
-using AdminWebsite.Services;
+﻿using AdminWebsite.Services;
 using AdminWebsite.UnitTests.Helper;
 using FluentAssertions;
-using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Moq;
-using NotificationApi.Client;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -16,9 +11,6 @@ using System.Threading.Tasks;
 using BookingsApi.Client;
 using BookingsApi.Contract.Enums;
 using BookingsApi.Contract.Responses;
-using VideoApi.Client;
-using Microsoft.Extensions.Options;
-using AdminWebsite.Configuration;
 using Autofac.Extras.Moq;
 using VideoApi.Contract.Responses;
 
@@ -36,7 +28,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         public void Setup()
         {
             _mocker = AutoMock.GetLoose();
-            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false))
                 .ReturnsAsync(new ConferenceDetailsResponse
                 {
                     MeetingRoom = new MeetingRoomResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetStatusHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetStatusHearingTests.cs
@@ -105,7 +105,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             AdminUri = "AdminUri", ParticipantUri = "ParticipantUri", JudgeUri = "JudgeUri", PexipNode = "PexipNode"} };
 
             // Arrange
-            _conferenceDetailsServiceMock.Setup(x => x.GetConferenceDetailsByHearingId(_guid))
+            _conferenceDetailsServiceMock.Setup(x => x.GetConferenceDetailsByHearingId(_guid, false))
                 .ReturnsAsync(conferenceResponse);
             _bookingsApiClientMock.Setup(x => x.GetBookingStatusByIdAsync(It.IsAny<Guid>())).ReturnsAsync(BookingStatus.Created);
 
@@ -118,7 +118,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             var hearing = (UpdateBookingStatusResponse)((OkObjectResult)result).Value;
             hearing.Success.Should().Be(true);
-            _conferenceDetailsServiceMock.Verify(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>()), Times.Once);
+            _conferenceDetailsServiceMock.Verify(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false), Times.Once);
             _bookingsApiClientMock.Verify(x => x.GetBookingStatusByIdAsync(It.IsAny<Guid>()), Times.Once);
         }
 
@@ -128,7 +128,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             ConferenceDetailsResponse conferenceResponse = new() { MeetingRoom = new MeetingRoomResponse() };
 
             // Arrange
-            _conferenceDetailsServiceMock.Setup(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+            _conferenceDetailsServiceMock.Setup(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false))
                 .ReturnsAsync(conferenceResponse);
             _bookingsApiClientMock.Setup(x => x.GetBookingStatusByIdAsync(It.IsAny<Guid>())).ReturnsAsync(BookingStatus.Created);
 
@@ -141,7 +141,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             var hearing = (UpdateBookingStatusResponse)((OkObjectResult)result).Value;
             hearing.Success.Should().Be(false);
-            _conferenceDetailsServiceMock.Verify(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>()), Times.Once);
+            _conferenceDetailsServiceMock.Verify(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false), Times.Once);
             _bookingsApiClientMock.Verify(x => x.GetBookingStatusByIdAsync(It.IsAny<Guid>()), Times.Once);
         }
 
@@ -151,7 +151,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             ConferenceDetailsResponse conferenceResponse = new() { MeetingRoom = new MeetingRoomResponse() };
 
             // Arrange
-            _conferenceDetailsServiceMock.Setup(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+            _conferenceDetailsServiceMock.Setup(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false))
                 .ReturnsAsync(conferenceResponse);
             _bookingsApiClientMock.Setup(x => x.GetBookingStatusByIdAsync(It.IsAny<Guid>())).ReturnsAsync(BookingStatus.Booked);
 
@@ -164,7 +164,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             var hearing = (UpdateBookingStatusResponse)((OkObjectResult)result).Value;
             hearing.Success.Should().Be(false);
-            _conferenceDetailsServiceMock.Verify(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>()), Times.Never);
+            _conferenceDetailsServiceMock.Verify(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false), Times.Never);
             _bookingsApiClientMock.Verify(x => x.GetBookingStatusByIdAsync(It.IsAny<Guid>()), Times.Once);
         }
 
@@ -211,7 +211,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             // Arrange
             _bookingsApiClientMock.Setup(x => x.GetBookingStatusByIdAsync(It.IsAny<Guid>())).ReturnsAsync(BookingStatus.Created);
-            _conferenceDetailsServiceMock.Setup(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>())).Throws(new VideoApiException("Error", 400, null, null, null));
+            _conferenceDetailsServiceMock.Setup(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false)).Throws(new VideoApiException("Error", 400, null, null, null));
             // Act
             var result = await _controller.GetHearingConferenceStatus(_guid);
 

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetTelephoneConferenceIdTest.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/GetTelephoneConferenceIdTest.cs
@@ -43,7 +43,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                     TelephoneConferenceId = "expected_conference_phone_id"
                 }
             };
-            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), true))
                 .ReturnsAsync(_conference);
             
             _controller = _mocker.Create<AdminWebsite.Controllers.HearingsController>();
@@ -74,7 +74,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         [Test]
         public void Should_return_bad_request_if_exceptions_is_thrown()
         {
-            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>())).Throws(new VideoApiException("Error", 400, null, null, null));
+            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), true)).Throws(new VideoApiException("Error", 400, null, null, null));
             
             var result = _controller.GetTelephoneConferenceIdById(_guid);
             var okRequestResult = (BadRequestObjectResult)result.Result;
@@ -84,7 +84,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         [Test]
         public void Should_return_not_found_if_exceptions_is_thrown()
         {
-            _mocker.Mock<IConferenceDetailsService>().Setup(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+            _mocker.Mock<IConferenceDetailsService>().Setup(x => x.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), true))
                 .Throws(new VideoApiException("Error", 404, null, null, null));
 
             var result = _controller.GetTelephoneConferenceIdById(_guid);

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/PostHearingTests.cs
@@ -40,7 +40,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         {
             _mocker = AutoMock.GetLoose();
 
-            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false))
                 .ReturnsAsync(new ConferenceDetailsResponse
                 {
                     MeetingRoom = new MeetingRoomResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/SearchForAudioRecordedHearingsTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/SearchForAudioRecordedHearingsTests.cs
@@ -39,7 +39,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         {
             _mocker = AutoMock.GetLoose();
 
-            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false))
                 .ReturnsAsync(new ConferenceDetailsResponse
                 {
                     MeetingRoom = new MeetingRoomResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/UpdateBookingStatusTests.cs
@@ -33,7 +33,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         {
             _mocker = AutoMock.GetLoose();
 
-            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+            _mocker.Mock<IConferenceDetailsService>().Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false))
                 .ReturnsAsync(new ConferenceDetailsResponse
                 {
                     MeetingRoom = new MeetingRoomResponse

--- a/AdminWebsite/AdminWebsite.UnitTests/Services/HearingServiceTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Services/HearingServiceTests.cs
@@ -47,7 +47,7 @@ namespace AdminWebsite.UnitTests.Services
             });
 
             _mocker.Mock<IConferenceDetailsService>()
-                .Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>()))
+                .Setup(cs => cs.GetConferenceDetailsByHearingId(It.IsAny<Guid>(), false))
                 .ReturnsAsync(new ConferenceDetailsResponse
                 {
                     MeetingRoom = new MeetingRoomResponse

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -541,7 +541,7 @@ namespace AdminWebsite.Controllers
         {
             try
             {
-                var conferenceDetailsResponse = await _conferenceDetailsService.GetConferenceDetailsByHearingId(hearingId);
+                var conferenceDetailsResponse = await _conferenceDetailsService.GetConferenceDetailsByHearingId(hearingId, true);
 
                 if (conferenceDetailsResponse.HasValidMeetingRoom())
                     return Ok(new PhoneConferenceResponse

--- a/AdminWebsite/AdminWebsite/Services/ConferenceDetailsService.cs
+++ b/AdminWebsite/AdminWebsite/Services/ConferenceDetailsService.cs
@@ -15,7 +15,7 @@ namespace AdminWebsite.Services
     {
         Task<ConferenceDetailsResponse> GetConferenceDetailsByHearingIdWithRetry(Guid hearingId, string errorMessage);
 
-        Task<ConferenceDetailsResponse> GetConferenceDetailsByHearingId(Guid hearingId);
+        Task<ConferenceDetailsResponse> GetConferenceDetailsByHearingId(Guid hearingId, bool includeClosed = false);
     }
     
     public class ConferenceDetailsService : IConferenceDetailsService
@@ -54,9 +54,9 @@ namespace AdminWebsite.Services
             return new ConferenceDetailsResponse();
         }
 
-        public async Task<ConferenceDetailsResponse> GetConferenceDetailsByHearingId(Guid hearingId)
+        public async Task<ConferenceDetailsResponse> GetConferenceDetailsByHearingId(Guid hearingId, bool includeClosed = false)
         {
-            return await _videoApiClient.GetConferenceByHearingRefIdAsync(hearingId, false);
+            return await _videoApiClient.GetConferenceByHearingRefIdAsync(hearingId, includeClosed);
         }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9708

### Change description ###
Added optional parameter to GetConferenceDetailsByHearingID, to allow querying of closed hearings. This is to cater for the edge case that a vho is still on the hearing details page of a hearing, just after it closes and they request the telephone conference ID which will return a 404 if the hearing has closed. Should not matter whether or not the hearing has closed in this particular request, as it's only fetching database data (telephone no.)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
