### PR TITLE
VIH-9631 display icon for non availability clash fix 

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/allocate-hearings/models/allocate-hearing.model.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/allocate-hearings/models/allocate-hearing.model.ts
@@ -134,7 +134,7 @@ export class AllocateHearingModel {
             originalHearing.allocated_cso,
             originalHearing.has_work_hours_clash,
             originalHearing.concurrent_hearings_count,
-            false
+            originalHearing.has_non_availability_clash
         );
     }
 


### PR DESCRIPTION
Fixed the issue where ticket was failed in Manual QA , someone forgot to reset hardset code

**Before creating a pull request make sure that:**



### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-9631

### Change description ###

This PR addresses the bug fix where i con was not displaying when vho has nonavailability clash . 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
