### PR TITLE
VIH-9757 Allocate hearings content poking through modal dialogs

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/styles.css
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/styles.css
@@ -197,6 +197,7 @@ p {
     justify-content: center;
     background: rgba(0, 0, 0, 0.7);
     transition: opacity 500ms;
+    z-index: 2;
 }
 
 .popup-small {


### PR DESCRIPTION
### **JIRA link**

https://tools.hmcts.net/jira/browse/VIH-9757

### **Change description**

The "Allocate hearings" content on the work allocation page was showing through the "Add a justice user" modal. To resolve this issue, I have increased the z-index of the popup-overlay modal to 2. Longer term, it may be worthwhile to use the Overlay components from the Angular material library as it seems like a more robust solution.