### PR TITLE
Added an 'open' attribute to the allocate hearings detail element, wh…

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/allocate-hearings/allocate-hearings.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/allocate-hearings/allocate-hearings.component.html
@@ -1,4 +1,4 @@
-<details class="govuk-details" data-module="govuk-details">
+<details class="govuk-details" data-module="govuk-details" open="{{ allocateHearingsDetailOpen }}">
   <summary class="govuk-details__summary" tabindex="0" role="button">
     <span class="govuk-details__summary-text" id="allocate-hearings"> Allocate hearings </span>
   </summary>


### PR DESCRIPTION
### **JIRA link**

https://tools.hmcts.net/jira/browse/VIH-9773

### **Change description**

When the links on the dashboard's “Upcoming unallocated hearings” panel were clicked, the Allocated hearings panel on the work allocation page did not show.

To resolve this issue, I have added an 'open' attribute to the allocate hearings detail element, which will be set true or false depending on the value of the allocateHearingsDetailOpen attribute.

