### PR TITLE
VIH-9696 - Add an endpoint to a hearing at the last minute

### DIFF
--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
@@ -39,6 +39,11 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
     public class EditHearingTests
     {
         private EditHearingRequest _addEndpointToHearingRequest;
+        private EditHearingRequest _addEndpointToHearingRequestWithJudge;
+        private EditHearingRequest _editEndpointOnHearingRequest;
+        private EditHearingRequest _editEndpointOnHearingRequestWithJudge;
+        private EditHearingRequest _removeEndpointOnHearingRequest;
+        private EditHearingRequest _removeEndpointOnHearingRequestWithJudge;
         private EditHearingRequest _addNewParticipantRequest;
         private EditHearingRequest _switchJudgeRequest;
         private EditHearingRequest _updateJudgeOtherInformationRequest;
@@ -207,12 +212,140 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 Participants = new List<EditParticipantRequest>(),
                 Endpoints = new List<EditEndpointRequest>
                 {
-                    new EditEndpointRequest
-                        {Id = null, DisplayName = "New Endpoint", DefenceAdvocateContactEmail = "username@hmcts.net"},
-                    new EditEndpointRequest
-                        {Id = guid1, DisplayName = "data1", DefenceAdvocateContactEmail = "edit-user@hmcts.net"},
-                    new EditEndpointRequest {Id = guid2, DisplayName = "data2-edit"},
-                    new EditEndpointRequest {Id = guid4, DisplayName = "data4-edit", DefenceAdvocateContactEmail = ""}
+                    new EditEndpointRequest { Id = null, DisplayName = "New Endpoint", DefenceAdvocateContactEmail = "username@hmcts.net" },
+                    new EditEndpointRequest { Id = guid1, DisplayName = "data1", DefenceAdvocateContactEmail = guid1.ToString() },
+                    new EditEndpointRequest { Id = guid2, DisplayName = "data2", DefenceAdvocateContactEmail = guid2.ToString() },
+                    new EditEndpointRequest { Id = guid3, DisplayName = "data3", DefenceAdvocateContactEmail = guid3.ToString() },
+                    new EditEndpointRequest { Id = guid4, DisplayName = "data4", DefenceAdvocateContactEmail = guid4.ToString() }
+                }
+            };
+
+            _addEndpointToHearingRequestWithJudge = new EditHearingRequest
+            {
+                Case = new EditCaseRequest { Name = "Case", Number = "123" },
+                Participants = new List<EditParticipantRequest>() 
+                { 
+                    new EditParticipantRequest() { 
+                        Id = guid1,
+                        CaseRoleName = "judge",
+                        HearingRoleName = HearingRoleName.Judge,
+                        FirstName = "FirstName",
+                        LastName = "LastName",
+                        ContactEmail = "judge@email.com",
+                        DisplayName = "FirstName LastName",
+                        LinkedParticipants = new List<LinkedParticipant>(),
+                        OrganisationName = "Org1",
+                        Representee = "Rep1",
+                        TelephoneNumber = "+44 123 1234",
+                        Title = "Mr",
+                        MiddleNames = "MiddleNames"
+                    } 
+                },
+                Endpoints = new List<EditEndpointRequest>
+                {
+                    new EditEndpointRequest { Id = null, DisplayName = "New Endpoint", DefenceAdvocateContactEmail = "username@hmcts.net" },
+                    new EditEndpointRequest { Id = guid1, DisplayName = "data1", DefenceAdvocateContactEmail = guid1.ToString() },
+                    new EditEndpointRequest { Id = guid2, DisplayName = "data2", DefenceAdvocateContactEmail = guid2.ToString() },
+                    new EditEndpointRequest { Id = guid3, DisplayName = "data3", DefenceAdvocateContactEmail = guid3.ToString() },
+                    new EditEndpointRequest { Id = guid4, DisplayName = "data4", DefenceAdvocateContactEmail = guid4.ToString() }
+                }
+            };
+
+            _editEndpointOnHearingRequest = new EditHearingRequest
+            {
+                Case = new EditCaseRequest 
+                { 
+                    Name = "Case", 
+                    Number = "123" 
+                },
+                Endpoints = new List<EditEndpointRequest>
+                {
+                    new EditEndpointRequest { Id = guid1, DisplayName = "data1", DefenceAdvocateContactEmail = guid1.ToString() },
+                    new EditEndpointRequest { Id = guid2, DisplayName = "data2", DefenceAdvocateContactEmail = guid2.ToString() },
+                    new EditEndpointRequest { Id = guid3, DisplayName = "data3", DefenceAdvocateContactEmail = guid3.ToString() },
+                    new EditEndpointRequest { Id = guid4, DisplayName = "data4-edit", DefenceAdvocateContactEmail = guid4.ToString() }
+                }
+            };
+
+            _editEndpointOnHearingRequestWithJudge = new EditHearingRequest
+            {
+                Case = new EditCaseRequest
+                {
+                    Name = "Case",
+                    Number = "123"
+                },
+                Participants = new List<EditParticipantRequest>()
+                {
+                    new EditParticipantRequest() {
+                        Id = guid1,
+                        CaseRoleName = "judge",
+                        HearingRoleName = HearingRoleName.Judge,
+                        FirstName = "FirstName",
+                        LastName = "LastName",
+                        ContactEmail = "judge@email.com",
+                        DisplayName = "FirstName LastName",
+                        LinkedParticipants = new List<LinkedParticipant>(),
+                        OrganisationName = "Org1",
+                        Representee = "Rep1",
+                        TelephoneNumber = "+44 123 1234",
+                        Title = "Mr",
+                        MiddleNames = "MiddleNames"
+                    }
+                },
+                Endpoints = new List<EditEndpointRequest>
+                {
+                    new EditEndpointRequest { Id = guid1, DisplayName = "data1", DefenceAdvocateContactEmail = guid1.ToString() },
+                    new EditEndpointRequest { Id = guid2, DisplayName = "data2", DefenceAdvocateContactEmail = guid2.ToString() },
+                    new EditEndpointRequest { Id = guid3, DisplayName = "data3", DefenceAdvocateContactEmail = guid3.ToString() },
+                    new EditEndpointRequest { Id = guid4, DisplayName = "data4-edit", DefenceAdvocateContactEmail = guid4.ToString() }
+                }
+            };
+
+            _removeEndpointOnHearingRequest = new EditHearingRequest
+            {
+                Case = new EditCaseRequest
+                {
+                    Name = "Case",
+                    Number = "123"
+                },
+                Endpoints = new List<EditEndpointRequest>
+                {
+                    new EditEndpointRequest { Id = guid1, DisplayName = "data1", DefenceAdvocateContactEmail = guid1.ToString() },
+                    new EditEndpointRequest { Id = guid2, DisplayName = "data2", DefenceAdvocateContactEmail = guid2.ToString() },
+                    new EditEndpointRequest { Id = guid3, DisplayName = "data3", DefenceAdvocateContactEmail = guid3.ToString() }
+                }
+            };
+
+            _removeEndpointOnHearingRequestWithJudge = new EditHearingRequest
+            {
+                Case = new EditCaseRequest
+                {
+                    Name = "Case",
+                    Number = "123"
+                },
+                Participants = new List<EditParticipantRequest>()
+                {
+                    new EditParticipantRequest() {
+                        Id = guid1,
+                        CaseRoleName = "judge",
+                        HearingRoleName = HearingRoleName.Judge,
+                        FirstName = "FirstName",
+                        LastName = "LastName",
+                        ContactEmail = "judge@email.com",
+                        DisplayName = "FirstName LastName",
+                        LinkedParticipants = new List<LinkedParticipant>(),
+                        OrganisationName = "Org1",
+                        Representee = "Rep1",
+                        TelephoneNumber = "+44 123 1234",
+                        Title = "Mr",
+                        MiddleNames = "MiddleNames"
+                    }
+                },
+                Endpoints = new List<EditEndpointRequest>
+                {
+                    new EditEndpointRequest { Id = guid1, DisplayName = "data1", DefenceAdvocateContactEmail = guid1.ToString() },
+                    new EditEndpointRequest { Id = guid2, DisplayName = "data2", DefenceAdvocateContactEmail = guid2.ToString() },
+                    new EditEndpointRequest { Id = guid3, DisplayName = "data3", DefenceAdvocateContactEmail = guid3.ToString() }
                 }
             };
 
@@ -222,18 +355,10 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 Participants = new List<ParticipantResponse>(),
                 Endpoints = new List<EndpointResponse>
                 {
-                    new EndpointResponse {DisplayName = "data1", Id = guid1, Pin = "0000", Sip = "1111111111"},
-                    new EndpointResponse
-                    {
-                        DisplayName = "data2", Id = guid2, Pin = "1111", Sip = "2222222222",
-                        DefenceAdvocateId = Guid.NewGuid()
-                    },
-                    new EndpointResponse {DisplayName = "data3", Id = guid3, Pin = "2222", Sip = "5544332234"},
-                    new EndpointResponse
-                    {
-                        DisplayName = "data4", Id = guid4, Pin = "2222", Sip = "5544332234",
-                        DefenceAdvocateId = Guid.NewGuid()
-                    }
+                    new EndpointResponse { Id = guid1, DisplayName = "data1", Pin = "0000", Sip = "1111111111", DefenceAdvocateId = guid1 },
+                    new EndpointResponse { Id = guid2, DisplayName = "data2", Pin = "1111", Sip = "2222222222", DefenceAdvocateId = guid2 },
+                    new EndpointResponse { Id = guid3, DisplayName = "data3", Pin = "2222", Sip = "5544332234", DefenceAdvocateId = guid3 },
+                    new EndpointResponse { Id = guid4, DisplayName = "data4", Pin = "2222", Sip = "5544332234", DefenceAdvocateId = guid4 }
                 },
                 Cases = cases,
                 CaseTypeName = "Unit Test",
@@ -383,7 +508,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                         !u.Cases.IsNullOrEmpty() && u.QuestionnaireNotRequired == false)),
                 Times.Once);
         }
-        
+
         [Test]
         public async Task Should_allow_updating_judge_other_information_prior_30_minutes_of_hearing_starting()
         {
@@ -405,7 +530,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         }
 
         [Test]
-        public async Task
+        public async Task 
             Should_allow_edit_confirmed_hearing_up_until_30_minutes_before_starting()
         {
             _updatedExistingParticipantHearingOriginal.ScheduledDateTime = DateTime.UtcNow.AddHours(1);
@@ -492,7 +617,6 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             Assert.ThrowsAsync<BookingsApiException>(async () => await _controller.EditHearing(_validId, _addNewParticipantRequest));
         }
 
-
         [Test]
         public async Task Should_return_bad_request_if_editing_hearing_fails_with_bad_request_status_code()
         {
@@ -570,7 +694,6 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             ((OkObjectResult)result.Result).StatusCode.Should().Be(200);
             _bookingsApiClient.Verify(x => x.UpdateHearingDetailsAsync(It.IsAny<Guid>(), It.IsAny<UpdateHearingRequest>()));
         }
-
 
         [Test]
         public async Task Should_not_send_email_for_existing_individual_participant_added()
@@ -725,7 +848,37 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                 Times.Once);
             _bookingsApiClient.Verify(
                 x => x.UpdateDisplayNameForEndpointAsync(It.IsAny<Guid>(), It.IsAny<Guid>(),
-                    It.IsAny<UpdateEndpointRequest>()), Times.Exactly(3));
+                    It.IsAny<UpdateEndpointRequest>()), Times.Never);
+            _bookingsApiClient.Verify(
+                x => x.RemoveEndPointFromHearingAsync(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Never);
+        }
+
+        [Test]
+        public async Task Should_add_endpoint_if_new_endpoint_is_added_to_endpoint_list_prior_30_minutes_of_hearing_starting()
+        {
+            _existingHearingWithEndpointsOriginal.ScheduledDateTime = DateTime.UtcNow.AddMinutes(20);
+            _existingHearingWithEndpointsOriginal.Status = BookingStatus.Created;
+
+            _bookingsApiClient.Setup(x => x.GetHearingDetailsByIdAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(_existingHearingWithEndpointsOriginal);
+
+            var result = await _controller.EditHearing(_validId, _addEndpointToHearingRequestWithJudge);
+
+            ((OkObjectResult)result.Result).StatusCode.Should().Be(200);
+
+            _bookingsApiClient.Verify(
+                x => x.AddEndPointToHearingAsync(It.IsAny<Guid>(), It.IsAny<AddEndpointRequest>()), Times.Once);
+
+            _bookingsApiClient.Verify(x => x.UpdateHearingDetailsAsync(It.IsAny<Guid>(),
+                    It.Is<UpdateHearingRequest>(u =>
+                        !u.Cases.IsNullOrEmpty() && u.QuestionnaireNotRequired == false)), Times.Once);
+
+            _bookingsApiClient.Verify(
+                x => x.UpdateDisplayNameForEndpointAsync(It.IsAny<Guid>(), It.IsAny<Guid>(),
+                    It.IsAny<UpdateEndpointRequest>()), Times.Never);
+
+            _bookingsApiClient.Verify(
+                x => x.RemoveEndPointFromHearingAsync(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Never);
         }
 
         [Test]
@@ -733,11 +886,47 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         {
             _bookingsApiClient.Setup(x => x.GetHearingDetailsByIdAsync(It.IsAny<Guid>()))
                 .ReturnsAsync(_existingHearingWithEndpointsOriginal);
-            var result = await _controller.EditHearing(_validId, _addEndpointToHearingRequest);
+            var result = await _controller.EditHearing(_validId, _editEndpointOnHearingRequest);
             ((OkObjectResult)result.Result).StatusCode.Should().Be(200);
             _bookingsApiClient.Verify(
+                x => x.AddEndPointToHearingAsync(It.IsAny<Guid>(), It.IsAny<AddEndpointRequest>()), Times.Never);
+            _bookingsApiClient.Verify(x => x.UpdateHearingDetailsAsync(It.IsAny<Guid>(),
+                    It.Is<UpdateHearingRequest>(u =>
+                        !u.Cases.IsNullOrEmpty() && u.QuestionnaireNotRequired == false)), Times.Once);
+            _bookingsApiClient.Verify(
                 x => x.UpdateDisplayNameForEndpointAsync(It.IsAny<Guid>(), It.IsAny<Guid>(),
-                    It.IsAny<UpdateEndpointRequest>()), Times.Exactly(3));
+                    It.IsAny<UpdateEndpointRequest>()), Times.Once);
+            _bookingsApiClient.Verify(x => x.RemoveEndPointFromHearingAsync(It.IsAny<Guid>(), It.IsAny<Guid>()),
+                Times.Never);
+
+        }
+
+        [Test]
+        public async Task Should_update_endpoint_if_an_endpoint_is_updates_in_endpoint_list_prior_30_minutes_of_hearing_starting()
+        {
+            _existingHearingWithEndpointsOriginal.ScheduledDateTime = DateTime.UtcNow.AddMinutes(20);
+            _existingHearingWithEndpointsOriginal.Status = BookingStatus.Created;
+
+            _bookingsApiClient.Setup(x => x.GetHearingDetailsByIdAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(_existingHearingWithEndpointsOriginal);
+
+            var result = await _controller.EditHearing(_validId, _editEndpointOnHearingRequestWithJudge);
+
+            ((OkObjectResult)result.Result).StatusCode.Should().Be(200);
+
+            _bookingsApiClient.Verify(
+                x => x.AddEndPointToHearingAsync(It.IsAny<Guid>(), It.IsAny<AddEndpointRequest>()), Times.Never);
+
+            _bookingsApiClient.Verify(x => x.UpdateHearingDetailsAsync(It.IsAny<Guid>(),
+                    It.Is<UpdateHearingRequest>(u =>
+                        !u.Cases.IsNullOrEmpty() && u.QuestionnaireNotRequired == false)), Times.Once);
+
+            _bookingsApiClient.Verify(
+                x => x.UpdateDisplayNameForEndpointAsync(It.IsAny<Guid>(), It.IsAny<Guid>(),
+                    It.IsAny<UpdateEndpointRequest>()), Times.Exactly(1));
+
+            _bookingsApiClient.Verify(
+                x => x.RemoveEndPointFromHearingAsync(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Never);
         }
 
         [Test]
@@ -745,17 +934,22 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         {
             _bookingsApiClient.Setup(x => x.GetHearingDetailsByIdAsync(It.IsAny<Guid>()))
                 .ReturnsAsync(_existingHearingWithEndpointsOriginal);
-            var result = await _controller.EditHearing(_validId, _addEndpointToHearingRequest);
+            var result = await _controller.EditHearing(_validId, _removeEndpointOnHearingRequest);
             ((OkObjectResult)result.Result).StatusCode.Should().Be(200);
+
+            _bookingsApiClient.Verify(
+                x => x.AddEndPointToHearingAsync(It.IsAny<Guid>(), It.IsAny<AddEndpointRequest>()), Times.Never);
+
             _bookingsApiClient.Verify(x => x.RemoveEndPointFromHearingAsync(It.IsAny<Guid>(), It.IsAny<Guid>()),
                 Times.Once);
+
             _bookingsApiClient.Verify(x => x.UpdateHearingDetailsAsync(It.IsAny<Guid>(),
                     It.Is<UpdateHearingRequest>(u =>
-                        !u.Cases.IsNullOrEmpty() && u.QuestionnaireNotRequired == false)),
-                Times.Once);
+                        !u.Cases.IsNullOrEmpty() && u.QuestionnaireNotRequired == false)), Times.Once);
+
             _bookingsApiClient.Verify(
                 x => x.UpdateDisplayNameForEndpointAsync(It.IsAny<Guid>(), It.IsAny<Guid>(),
-                    It.IsAny<UpdateEndpointRequest>()), Times.Exactly(3));
+                    It.IsAny<UpdateEndpointRequest>()), Times.Never);
         }
 
         [Test]
@@ -798,20 +992,30 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
         public async Task Should_not_update_DisplayName_if_no_matching_endpoint_exists_in_list()
         {
             _existingHearingWithEndpointsOriginal.Endpoints[0].Id = Guid.NewGuid();
-            _existingHearingWithEndpointsOriginal.Endpoints[1].DisplayName = "data2-edit";
-            _existingHearingWithEndpointsOriginal.Endpoints[1].DefenceAdvocateId = null;
+            _existingHearingWithEndpointsOriginal.Endpoints[0].DisplayName = "data1-edit";
+            _existingHearingWithEndpointsOriginal.Endpoints[0].DefenceAdvocateId = null;
             _existingHearingWithEndpointsOriginal.Endpoints[3].DisplayName = "data4-edit";
             _existingHearingWithEndpointsOriginal.Endpoints[3].DefenceAdvocateId = null;
+
             _bookingsApiClient.Setup(x => x.GetHearingDetailsByIdAsync(It.IsAny<Guid>()))
                 .ReturnsAsync(_existingHearingWithEndpointsOriginal);
+
             var result = await _controller.EditHearing(_validId, _addEndpointToHearingRequest);
+
             ((OkObjectResult)result.Result).StatusCode.Should().Be(200);
-            _bookingsApiClient.Verify(x => x.RemoveEndPointFromHearingAsync(It.IsAny<Guid>(), It.IsAny<Guid>()),
-                Times.Exactly(2));
+
+            _bookingsApiClient.Verify(
+                x => x.AddEndPointToHearingAsync(It.IsAny<Guid>(), It.IsAny<AddEndpointRequest>()), Times.Once);
+
+            // The old Endpoints[0] has no matching Id now, and so it will be removed
+            _bookingsApiClient.Verify(
+                x => x.RemoveEndPointFromHearingAsync(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Once);
+
             _bookingsApiClient.Verify(x => x.UpdateHearingDetailsAsync(It.IsAny<Guid>(),
                     It.Is<UpdateHearingRequest>(u =>
-                        !u.Cases.IsNullOrEmpty() && u.QuestionnaireNotRequired == false)),
-                Times.Once);
+                        !u.Cases.IsNullOrEmpty() && u.QuestionnaireNotRequired == false)), Times.Once);
+
+            // Endpoints[3] has had their details changed, and so will be updated
             _bookingsApiClient.Verify(
                 x => x.UpdateDisplayNameForEndpointAsync(It.IsAny<Guid>(), It.IsAny<Guid>(),
                     It.IsAny<UpdateEndpointRequest>()), Times.Once);

--- a/AdminWebsite/AdminWebsite.UnitTests/Services/HearingServiceTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Services/HearingServiceTests.cs
@@ -123,7 +123,6 @@ namespace AdminWebsite.UnitTests.Services
             };
         }
 
- 
         [Test]
         public void Should_return_false_if_HearingRoomName_is_not_changed()
         {
@@ -178,7 +177,7 @@ namespace AdminWebsite.UnitTests.Services
         }
 
         [Test]
-        public void Should_return_false_when_endpoint_count_is_changed()
+        public void Should_return_true_when_endpoint_count_is_changed()
         {
             _editHearingRequest.Endpoints.Add(new EditEndpointRequest
             {
@@ -188,20 +187,20 @@ namespace AdminWebsite.UnitTests.Services
             });
             _editHearingRequest.Participants.Add(new EditParticipantRequest { Id = Guid.NewGuid() });
 
-            Assert.False(_service.IsAddingParticipantOnly(_editHearingRequest,
+            Assert.True(_service.HasEndpointsBeenChanged(_editHearingRequest,
                 _updatedExistingParticipantHearingOriginal));
         }
 
         [Test]
-        public void Should_return_false_when_endpoint_displayName_is_changed()
+        public void Should_return_true_when_endpoint_displayName_is_changed()
         {
             _editHearingRequest.Endpoints.First().DisplayName = "test1";
-            Assert.False(_service.IsAddingParticipantOnly(_editHearingRequest,
+            Assert.True(_service.HasEndpointsBeenChanged(_editHearingRequest,
                 _updatedExistingParticipantHearingOriginal));
         }
 
         [Test]
-        public void Should_return_false_when_endpoint_removed()
+        public void Should_return_true_when_endpoint_removed()
         {
             _updatedExistingParticipantHearingOriginal.Endpoints.Add(new EndpointResponse
             {
@@ -211,15 +210,15 @@ namespace AdminWebsite.UnitTests.Services
             });
             _editHearingRequest.Participants.Add(new EditParticipantRequest { Id = Guid.NewGuid() });
 
-            Assert.False(_service.IsAddingParticipantOnly(_editHearingRequest,
+            Assert.True(_service.HasEndpointsBeenChanged(_editHearingRequest,
                 _updatedExistingParticipantHearingOriginal));
         }
 
         [Test]
-        public void Should_return_false_when_endpoint_defenceAdvocateUsername_is_changed()
+        public void Should_return_true_when_endpoint_defenceAdvocateUsername_is_changed()
         {
             _updatedExistingParticipantHearingOriginal.Endpoints.First().DefenceAdvocateId = Guid.NewGuid();
-            Assert.False(_service.IsAddingParticipantOnly(_editHearingRequest,
+            Assert.True(_service.HasEndpointsBeenChanged(_editHearingRequest,
                 _updatedExistingParticipantHearingOriginal));
         }
 
@@ -247,6 +246,36 @@ namespace AdminWebsite.UnitTests.Services
             var editParticipants2 = new List<EditParticipantRequest> { participantRequest1 };
 
             Assert.True(_service.GetAddedParticipant(editParticipants1, editParticipants2).Count == 0);
+        }
+
+        [Test]
+        public void Should_have_one_added_participant()
+        {
+            var originalParticipants = new List<EditParticipantRequest> 
+            { 
+                new EditParticipantRequest 
+                { 
+                    Id = It.IsAny<Guid>(), 
+                    DisplayName = "Test" 
+                } 
+            };
+
+            // This should contain the existing participants as well as the new participants
+            var editParticipantRequest = new List<EditParticipantRequest> 
+            { 
+                new EditParticipantRequest 
+                { 
+                    Id = It.IsAny<Guid>(), 
+                    DisplayName = "Test" 
+                }, 
+                new EditParticipantRequest 
+                { 
+                    Id = It.IsAny<Guid>(), 
+                    DisplayName = "Test2" 
+                } 
+            };
+
+            Assert.AreEqual(1, _service.GetAddedParticipant(originalParticipants, editParticipantRequest).Count);
         }
 
         [Test]

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/booking-routing.module.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/booking-routing.module.ts
@@ -23,7 +23,7 @@ export const routes: Routes = [
         data: { exceptionToRuleCheck: true }
     },
     { path: 'add-participants', component: AddParticipantComponent, canActivate: [AuthGuard, AdminGuard] },
-    { path: 'video-access-points', component: EndpointsComponent, canActivate: [AuthGuard, AdminGuard, LastMinuteAmendmentsGuard] },
+    { path: 'video-access-points', component: EndpointsComponent, canActivate: [AuthGuard, AdminGuard] },
     { path: 'other-information', component: OtherInformationComponent, canActivate: [AuthGuard, AdminGuard, LastMinuteAmendmentsGuard] },
     { path: 'summary', component: SummaryComponent, canActivate: [AuthGuard, AdminGuard] },
     { path: 'booking-confirmation', component: BookingConfirmationComponent, canActivate: [AuthGuard, AdminGuard] }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/breadcrumb/breadcrumbItems.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/breadcrumb/breadcrumbItems.ts
@@ -39,7 +39,7 @@ export const BreadcrumbItems: BreadcrumbItemModel[] = [
         Name: 'Video access points',
         Url: '/video-access-points',
         Active: false,
-        LastMinuteAmendable: false
+        LastMinuteAmendable: true
     },
     {
         Id: 6,

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/endpoints/endpoints.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/endpoints/endpoints.component.html
@@ -6,89 +6,90 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">Video access points</h2>
+    <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">Video access points</h2>
 
-    <div
-      *ngIf="failedValidation"
-      class="govuk-error-summary govuk-!-width-full"
-      aria-labelledby="error-summary-title"
-      role="alert"
-      tabindex="-1"
-      data-module="error-summary"
-    >
-      <h2 class="govuk-error-summary__title" id="error-summary-title">Please complete the missing information</h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          <li *ngIf="duplicateDa">Please enter a unique display name</li>
-        </ul>
-      </div>
-    </div>
-
-    <form [formGroup]="form" (ngSubmit)="saveEndpoints()">
-      <div formArrayName="endpoints" *ngFor="let endpoint of endpoints.controls; let i = index; let lst = last">
-        <div [formGroupName]="i">
-          <div class="govuk-form-group" [ngClass]="{ 'has-error': endpoints.controls[i].invalid && endpoints.controls[i].touched }">
-            <label class="govuk-label govuk-!-width-one-half" [attr.for]="'displayName' + i"> Display name </label>
-            <input [id]="'displayName' + i" class="govuk-input govuk-!-width-three-quarters" type="text" formControlName="displayName" />
-            <a
-              *ngIf="endpoints.length > 1"
-              [id]="'removeDisplayName' + i"
-              class="govuk-link govuk-!-margin-left-2"
-              href="javascript:void(0)"
-              (click)="removeEndpoint(i)"
-              >Remove</a
-            >
-          </div>
-          <div class="govuk-form-group">
-            <label class="govuk-label govuk-!-width-full" [attr.for]="'defenceAdvocate' + i">
-              Link an advocate to this video access point?
-            </label>
-            <select class="govuk-select ddl-width" [id]="'defenceAdvocate' + i" formControlName="defenceAdvocate">
-              <option *ngFor="let da of availableDefenceAdvocates" [value]="da.contactEmail">
-                {{ da.displayName }}
-              </option>
-            </select>
-          </div>
+        <div
+             *ngIf="failedValidation"
+             class="govuk-error-summary govuk-!-width-full"
+             aria-labelledby="error-summary-title"
+             role="alert"
+             tabindex="-1"
+             data-module="error-summary"
+             >
+            <h2 class="govuk-error-summary__title" id="error-summary-title">Please complete the missing information</h2>
+            <div class="govuk-error-summary__body">
+                <ul class="govuk-list govuk-error-summary__list">
+                    <li *ngIf="duplicateDa">Please enter a unique display name</li>
+                </ul>
+            </div>
         </div>
-        <div *ngIf="!lst" class="vh-line" style="margin-bottom: 10px"></div>
-      </div>
-    </form>
 
-    <div>
-      <button
-        id="addEndpoint"
-        class="govuk-button"
-        data-module="govuk-button"
-        (click)="addEndpoint()"
-        alt="Add endpoint"
-        [disabled]="endpoints.invalid"
-      >
-        Add another
-      </button>
-    </div>
-    <div>
-      <button
-        id="nextButton"
-        class="govuk-button govuk-!-margin-right-2"
-        data-module="govuk-button"
-        alt="Save endpoints"
-        (click)="saveEndpoints()"
-      >
-        {{ buttonAction }}
-      </button>
+        <form [formGroup]="form" (ngSubmit)="saveEndpoints()">
+            <div formArrayName="endpoints" *ngFor="let endpoint of endpoints.controls; let i = index; let lst = last">
+                <div [formGroupName]="i">
+                    <div class="govuk-form-group" [ngClass]="{ 'has-error': endpoints.controls[i].invalid && endpoints.controls[i].touched }">
+                        <label class="govuk-label govuk-!-width-one-half" [attr.for]="'displayName' + i"> Display name </label>
+                        <input [id]="'displayName' + i" class="govuk-input govuk-!-width-three-quarters" type="text" formControlName="displayName" />
+                        <a *ngIf="endpoints.length > 1 && !videoHearingService.isHearingAboutToStart()" [id]="'removeDisplayName' + i" class="govuk-link govuk-!-margin-left-2"
+                           href="javascript:void(0)" (click)="removeEndpoint(i)">
+                            Remove
+                        </a>
+                        <a *ngIf="endpoints.length > 1 && videoHearingService.isHearingAboutToStart()" [id]="'removeDisplayName' + i" class="govuk-link govuk-!-margin-left-2"
+                           href="javascript:void(0)" [disabled]="videoHearingService.isHearingAboutToStart()"
+                           appTooltip [text]="'Cannot remove an endpoint when hearing is about to start'" [colour]="'blue'">
+                            Remove
+                        </a>
+                    </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-!-width-full" [attr.for]="'defenceAdvocate' + i">
+                            Link an advocate to this video access point?
+                        </label>
+                        <select class="govuk-select ddl-width" [id]="'defenceAdvocate' + i" formControlName="defenceAdvocate">
+                            <option *ngFor="let da of availableDefenceAdvocates" [value]="da.contactEmail">
+                                {{ da.displayName }}
+                            </option>
+                        </select>
+                    </div>
+                </div>
+                <div *ngIf="!lst" class="vh-line" style="margin-bottom: 10px"></div>
+            </div>
+        </form>
 
-      <button
-        id="cancelButton"
-        class="govuk-button govuk-button--secondary"
-        data-module="govuk-button"
-        (click)="cancelBooking()"
-        alt="Confirm cancellation of new booking and return to dashboard"
-      >
-        Cancel
-      </button>
+        <div>
+            <button
+                    id="addEndpoint"
+                    class="govuk-button"
+                    data-module="govuk-button"
+                    (click)="addEndpoint()"
+                    alt="Add endpoint"
+                    [disabled]="endpoints.invalid"
+                    >
+                Add another
+            </button>
+        </div>
+        <div>
+            <button
+                    id="nextButton"
+                    class="govuk-button govuk-!-margin-right-2"
+                    data-module="govuk-button"
+                    alt="Save endpoints"
+                    (click)="saveEndpoints()"
+                    >
+                {{ buttonAction }}
+            </button>
+
+            <button
+                    id="cancelButton"
+                    class="govuk-button govuk-button--secondary"
+                    data-module="govuk-button"
+                    (click)="cancelBooking()"
+                    alt="Confirm cancellation of new booking and return to dashboard"
+                    >
+                Cancel
+            </button>
+        </div>
     </div>
-  </div>
 </div>
 <div *ngIf="attemptingCancellation">
   <app-cancel-popup (continueBooking)="continueBooking($event)" (cancelBooking)="cancelEndpoints($event)"> </app-cancel-popup>

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/endpoints/endpoints.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/endpoints/endpoints.component.ts
@@ -109,8 +109,13 @@ export class EndpointsComponent extends BookingBaseComponent implements OnInit, 
     }
 
     removeEndpoint(rowIndex: number): void {
-        this.logger.debug(`${this.loggerPrefix} Removing endpoint at index position ${rowIndex}.`);
-        this.endpoints.removeAt(rowIndex);
+        if (!this.videoHearingService.isHearingAboutToStart()) {
+            this.logger.debug(`${this.loggerPrefix} Removing endpoint at index position ${rowIndex}.`);
+            this.endpoints.removeAt(rowIndex);
+        }
+        else {
+            this.logger.warn(`${this.loggerPrefix} Cannot remove an endpoint when hearing is about to start ${rowIndex}.`);
+        }
     }
 
     cancelBooking(): void {

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -217,8 +217,9 @@ namespace AdminWebsite.Controllers
             try
             {
                 if (IsHearingStartingSoon(originalHearing) && originalHearing.Status == BookingStatus.Created &&
-                    !_hearingsService.IsAddingParticipantOnly(request, originalHearing) && 
-                    !_hearingsService.IsUpdatingJudge(request, originalHearing))
+                    !_hearingsService.IsAddingParticipantOnly(request, originalHearing) &&
+                    !_hearingsService.IsUpdatingJudge(request, originalHearing) &&
+                    !_hearingsService.HasEndpointsBeenChanged(request, originalHearing))
                 {
                     var errorMessage =
                         $"You can't edit a confirmed hearing [{hearingId}] within {StartingSoonMinutesThreshold} minutes of it starting";
@@ -235,6 +236,7 @@ namespace AdminWebsite.Controllers
                     ModelState.AddModelError(nameof(hearingId), errorMessage);
                     return BadRequest(ModelState);
                 }
+
                 var updatedHearing = await _bookingsApiClient.GetHearingDetailsByIdAsync(hearingId);
                 //Save hearing details
                 var updateHearingRequest = HearingUpdateRequestMapper.MapTo(request, _userIdentity.GetUserIdentityName());


### PR DESCRIPTION
1. Front end blocks removal of endpoints when hearing starts in less than 30 minutes. 
2. Backend will check for differences between original endpoints and requested endpoints if in the hearing is in the Created status and hearing starts in less than 30 minutes. If it detects no changes between original and requested endpoints, it will return a false value, potentially causing the Edit to return an error.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
