### PR TITLE
VIH-9789 Recording in CACD case type should always be set to off

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.spec.ts
@@ -342,6 +342,17 @@ describe('SummaryComponent with valid request', () => {
         expect(component.hearing.linked_participants).toEqual([]);
         expect(component.hearing.participants).toEqual([]);
     });
+    it('should set audio recording to false if case type is CACD', () => {
+        component.hearing.case_type = 'Court of Appeal Criminal Division';
+        component.ngOnInit();
+        expect(component.hearing.audio_recording_required).toBe(false);
+    });
+    it('should set audio recording to true if an interpreter is present', () => {
+        component.interpreterPresent = true;
+        component.setAudioRecordingRequired(component.hearing.audio_recording_required);
+        fixture.detectChanges();
+        expect(component.hearing.audio_recording_required).toBe(true);
+    });
     it('should remove interpreter and clear the linked participant list on remove interpreter', () => {
         component.ngOnInit();
         component.hearing.participants = [];

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
@@ -93,8 +93,8 @@ export class SummaryComponent implements OnInit, OnDestroy {
         this.retrieveHearingSummary();
         this.switchOffRecording = this.recordingGuardService.switchOffRecording(this.hearing.case_type);
         this.interpreterPresent = this.recordingGuardService.mandatoryRecordingForHearingRole(this.hearing.participants);
-        this.hearing.audio_recording_required = this.interpreterPresent ? true : this.hearing.audio_recording_required;
-        this.retrieveHearingSummary();
+        this.hearing.audio_recording_required = this.setAudioRecordingRequired(this.hearing.audio_recording_required);
+            this.retrieveHearingSummary();
         if (this.participantsListComponent) {
             this.participantsListComponent.isEditMode = this.isExistingBooking;
             this.$subscriptions.push(
@@ -185,6 +185,16 @@ export class SummaryComponent implements OnInit, OnDestroy {
     removeEndpoint(rowIndex: number): void {
         this.hearing.endpoints.splice(rowIndex, 1);
         this.hearingService.updateHearingRequest(this.hearing);
+    }
+
+    setAudioRecordingRequired(currentValue: boolean): boolean {
+        if (this.caseType === 'Court of Appeal Criminal Division') {
+            return false;
+        }
+        if (this.interpreterPresent) {
+            return true;
+        }
+        return currentValue;
     }
 
     private formatCourtRoom(courtName, courtRoom) {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
@@ -116,7 +116,6 @@ export class SummaryComponent implements OnInit, OnDestroy {
     private confirmRemoveParticipant() {
         const participant = this.hearing.participants.find(x => x.email.toLowerCase() === this.selectedParticipantEmail.toLowerCase());
         const filteredParticipants = this.hearing.participants.filter(x => !x.is_judge);
-        const isNotLast = filteredParticipants && filteredParticipants.length > 1;
         const title = participant && participant.title ? `${participant.title}` : '';
         this.removerFullName = participant ? `${title} ${participant.first_name} ${participant.last_name}` : '';
 


### PR DESCRIPTION
### **JIRA link**
https://tools.hmcts.net/jira/browse/VIH-9789

### **Change description**
Court of Appeal Criminal Division hearing should always have recordings turned off, even if an interpreter is booked on. To resolve this the audio_recording_required (boolean) now has an additional condition that is only set  to true if an interpreter is present and the case type does not equal "Court of Appeal Criminal Division.