### PR TITLE
VIH-9884 Revert removal of special characters from endpoint name

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/endpoints/endpoints.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/endpoints/endpoints.component.spec.ts
@@ -218,16 +218,6 @@ describe('EndpointsComponent', () => {
         expect(routerSpy.navigate).toHaveBeenCalledWith(['/other-information']);
     });
 
-    it('it should remove special characters from displayName when entered', () => {
-        // Given
-        component.ngOnInit();
-        component.endpoints.controls[0].get('displayName').setValue('Adam^%<>');
-        // When
-        component.saveEndpoints();
-        // Then
-        expect(component.hearing.endpoints[0].displayName).toBe('Adam');
-    });
-
     it('it should filter  "Representative" user-types only as valid defenceAdvocates for JVM', () => {
         // arrange
         newHearing.participants = [

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/endpoints/endpoints.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/endpoints/endpoints.component.ts
@@ -3,7 +3,7 @@ import { AbstractControl, FormArray, FormBuilder, FormGroup } from '@angular/for
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { Constants } from 'src/app/common/constants';
-import { RemoveSpecialCharacters } from 'src/app/common/formatters/remove-special-characters';
+import { SanitizeInputText } from 'src/app/common/formatters/sanitize-input-text';
 import { DefenceAdvocateModel } from 'src/app/common/model/defence-advocate.model';
 import { EndpointModel } from 'src/app/common/model/endpoint.model';
 import { HearingModel } from 'src/app/common/model/hearing.model';
@@ -89,7 +89,7 @@ export class EndpointsComponent extends BookingBaseComponent implements OnInit, 
         for (const control of this.endpoints.controls) {
             const endpointModel = new EndpointModel();
             if (control.value.displayName.trim() !== '') {
-                const displayNameText = RemoveSpecialCharacters(control.value.displayName);
+                const displayNameText = SanitizeInputText(control.value.displayName);
                 endpointModel.displayName = displayNameText;
                 endpointModel.id = control.value.id;
                 endpointModel.defenceAdvocate = control.value.defenceAdvocate !== this.constants.None ? control.value.defenceAdvocate : '';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/endpoints/endpoints.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/endpoints/endpoints.component.ts
@@ -252,7 +252,7 @@ export class EndpointsComponent extends BookingBaseComponent implements OnInit, 
 
 function blankSpaceValidator(control: AbstractControl): { [key: string]: any } | null {
     const displayNameText: string = control.value;
-    if (displayNameText !== null && displayNameText.replace(/\s/g, '').length) {
+    if (displayNameText?.replace(/\s/g, '').length) {
         return null;
     } else {
         return { blankSpaceValidator: true };

--- a/azure-pipelines.sds.pr-release.yml
+++ b/azure-pipelines.sds.pr-release.yml
@@ -58,6 +58,8 @@ stages:
                 sonar.javascript.lcov.reportPaths=**/ClientApp/coverage/lcov.info
                 sonar.typescript.exclusions=**/node_modules/**, **/typings.d.ts, **/main.ts, **/environments/environment*.ts, **/*routing.module.ts, **/api-client.ts
                 sonar.coverage.exclusions=**/AdminWebsite/Configuration/**, **/AdminWebsite/Security/**, **/AdminWebsite.Testing.Common/**, **/AdminWebsite/Views/*, **/AdminWebsite/Pages/*, **/AdminWebsite.AcceptanceTests/*, **/AdminWebsite.*Tests/*
+                sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S6544
+                sonar.issue.ignore.multicriteria.e3.resourceKey=**/*.ts
 
   #####################################################
   # Build Docker Image. ###############################

--- a/azure-pipelines.sds.pr-release.yml
+++ b/azure-pipelines.sds.pr-release.yml
@@ -58,8 +58,9 @@ stages:
                 sonar.javascript.lcov.reportPaths=**/ClientApp/coverage/lcov.info
                 sonar.typescript.exclusions=**/node_modules/**, **/typings.d.ts, **/main.ts, **/environments/environment*.ts, **/*routing.module.ts, **/api-client.ts
                 sonar.coverage.exclusions=**/AdminWebsite/Configuration/**, **/AdminWebsite/Security/**, **/AdminWebsite.Testing.Common/**, **/AdminWebsite/Views/*, **/AdminWebsite/Pages/*, **/AdminWebsite.AcceptanceTests/*, **/AdminWebsite.*Tests/*
-                sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S6544
-                sonar.issue.ignore.multicriteria.e3.resourceKey=**/*.ts
+                sonar.issue.ignore.multicriteria=e1
+                sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S6544
+                sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.ts
 
   #####################################################
   # Build Docker Image. ###############################

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -328,6 +328,8 @@ extends:
         sonar.typescript.exclusions=**/node_modules/**, **/typings.d.ts, **/main.ts, **/environments/environment*.ts, **/*routing.module.ts, **/api-client.ts
         sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml
         sonar.coverage.exclusions=**/AdminWebsite/Configuration/**, **/AdminWebsite/Security/**, **/AdminWebsite.Testing.Common/**, **/AdminWebsite/Views/*, **/AdminWebsite/Pages/*, **/AdminWebsite.AcceptanceTests/*, **/AdminWebsite.*Tests/*
+        sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S6544
+        sonar.issue.ignore.multicriteria.e3.resourceKey=**/*.ts
     ACTest: ${{ parameters.RunACTests }}
     releaseParameters:
       environment: Preview

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -328,8 +328,9 @@ extends:
         sonar.typescript.exclusions=**/node_modules/**, **/typings.d.ts, **/main.ts, **/environments/environment*.ts, **/*routing.module.ts, **/api-client.ts
         sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml
         sonar.coverage.exclusions=**/AdminWebsite/Configuration/**, **/AdminWebsite/Security/**, **/AdminWebsite.Testing.Common/**, **/AdminWebsite/Views/*, **/AdminWebsite/Pages/*, **/AdminWebsite.AcceptanceTests/*, **/AdminWebsite.*Tests/*
-        sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S6544
-        sonar.issue.ignore.multicriteria.e3.resourceKey=**/*.ts
+        sonar.issue.ignore.multicriteria=e1
+        sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S6544
+        sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.ts
     ACTest: ${{ parameters.RunACTests }}
     releaseParameters:
       environment: Preview


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9884


### Change description ###

- Reverts a previous change to automatically strip special characters (slashes, hyphens etc) out of the endpoint name.
- Fixes a code smell
- Ignores a new SonarCloud rule (https://sonarcloud.io/organizations/hmcts/rules?open=typescript%3AS6544&rule_key=typescript%3AS6544) which is prominent throughout the codebase 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
