### PR TITLE
VIH-9898 Fix - icons displayed in manual allocation do not align

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/allocate-hearings/allocate-hearings.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/allocate-hearings/allocate-hearings.component.html
@@ -173,7 +173,7 @@
           </span>
         </td>
         <td></td>
-        <td class="govuk-table__cell no-border">
+        <td class="govuk-table__cell no-border align-middle">
           <span appTooltip [text]="'Hearing clashes with user non-availability'" [colour]="'blue'">
             <fa-icon id="clockIcon" *ngIf="hearing.hasNonAvailabilityClash" [icon]="faClock"></fa-icon
           ></span>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9898


### Change description ###
Changes the non-availability clash icon to be centrally aligned, like the other icons


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
