### PR TITLE
VIH-9924 form validation for existing user

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant-base/add-participant-base.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant-base/add-participant-base.component.ts
@@ -234,6 +234,10 @@ export abstract class AddParticipantBaseDirective extends BookingBaseComponent i
             delete formControlsObj['interpreterFor'];
         }
         this.form.setValue(formControlsObj);
+        (<any>Object).values(this.form.controls).forEach(control => {
+            control.markAsTouched();
+            control.markAsDirty();
+        });
 
         setTimeout(() => {
             this.form.get('role').setValue(this.participantDetails.hearing_role_name);


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-9924

### Change description ###

Somehow an existing user's phone number was invalid and when used in a future booking, the form's add participant button did not appear despite the phone number being invalid. The only way to display the error was to focus on on the field and leave it. Now the form is marked as dirty/touched when pre-populating to ensure the existing values are still considered valid.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
