### PR TITLE
VIH-9550 Retry booking should attempt to rebook the conference in video api

### DIFF
--- a/AdminWebsite/AdminWebsite.AcceptanceTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/packages.lock.json
@@ -152,8 +152,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.10-pr-0663-0003",
-        "contentHash": "kf7BuTVUOdd4KGAmdxV1UY3u9Rp8UWtlu/jp3CCY4CCmpIpdGyBqaSsFMZs269838vjrk1d2mZbXKaiLJVu+uQ==",
+        "resolved": "1.45.13-pr-0663-0010",
+        "contentHash": "+0V3k1wIjlxAC6202hJL9q+Xb891tM6sOkW349TMKKoZ2RY027EKODPdVAdPdOeuX3ymyEHtpN3g0vS+82NjnQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2632,7 +2632,7 @@
       "adminwebsite": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.10-pr-0663-0003, )",
+          "BookingsApi.Client": "[1.45.13-pr-0663-0010, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/packages.lock.json
@@ -152,8 +152,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.13-pr-0663-0010",
-        "contentHash": "+0V3k1wIjlxAC6202hJL9q+Xb891tM6sOkW349TMKKoZ2RY027EKODPdVAdPdOeuX3ymyEHtpN3g0vS+82NjnQ==",
+        "resolved": "1.45.15",
+        "contentHash": "EK0Iyd4i1LyoXw98tDRehbIl5iX23U4ucfwIcqcBVLa1AT7YsYtiR6LWCJi84vvvwnZjIh33ohmPlMDMg/lAyQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2632,7 +2632,7 @@
       "adminwebsite": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.13-pr-0663-0010, )",
+          "BookingsApi.Client": "[1.45.15, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite.AcceptanceTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.AcceptanceTests/packages.lock.json
@@ -152,8 +152,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.44.6",
-        "contentHash": "pr59SEWnlnkGyZmilLh+6JiUEZqLXn6iic5NVTEjO22VFs3Qij0RfZ2q+fotW2rk/tVcs0P2WGITt9kulBm5SQ==",
+        "resolved": "1.45.10-pr-0663-0003",
+        "contentHash": "kf7BuTVUOdd4KGAmdxV1UY3u9Rp8UWtlu/jp3CCY4CCmpIpdGyBqaSsFMZs269838vjrk1d2mZbXKaiLJVu+uQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2632,7 +2632,7 @@
       "adminwebsite": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.44.6, )",
+          "BookingsApi.Client": "[1.45.10-pr-0663-0003, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite.IntegrationTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.IntegrationTests/packages.lock.json
@@ -93,8 +93,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.44.6",
-        "contentHash": "pr59SEWnlnkGyZmilLh+6JiUEZqLXn6iic5NVTEjO22VFs3Qij0RfZ2q+fotW2rk/tVcs0P2WGITt9kulBm5SQ==",
+        "resolved": "1.45.10-pr-0663-0003",
+        "contentHash": "kf7BuTVUOdd4KGAmdxV1UY3u9Rp8UWtlu/jp3CCY4CCmpIpdGyBqaSsFMZs269838vjrk1d2mZbXKaiLJVu+uQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2064,7 +2064,7 @@
       "adminwebsite": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.44.6, )",
+          "BookingsApi.Client": "[1.45.10-pr-0663-0003, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite.IntegrationTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.IntegrationTests/packages.lock.json
@@ -93,8 +93,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.13-pr-0663-0010",
-        "contentHash": "+0V3k1wIjlxAC6202hJL9q+Xb891tM6sOkW349TMKKoZ2RY027EKODPdVAdPdOeuX3ymyEHtpN3g0vS+82NjnQ==",
+        "resolved": "1.45.15",
+        "contentHash": "EK0Iyd4i1LyoXw98tDRehbIl5iX23U4ucfwIcqcBVLa1AT7YsYtiR6LWCJi84vvvwnZjIh33ohmPlMDMg/lAyQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2064,7 +2064,7 @@
       "adminwebsite": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.13-pr-0663-0010, )",
+          "BookingsApi.Client": "[1.45.15, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite.IntegrationTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.IntegrationTests/packages.lock.json
@@ -93,8 +93,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.10-pr-0663-0003",
-        "contentHash": "kf7BuTVUOdd4KGAmdxV1UY3u9Rp8UWtlu/jp3CCY4CCmpIpdGyBqaSsFMZs269838vjrk1d2mZbXKaiLJVu+uQ==",
+        "resolved": "1.45.13-pr-0663-0010",
+        "contentHash": "+0V3k1wIjlxAC6202hJL9q+Xb891tM6sOkW349TMKKoZ2RY027EKODPdVAdPdOeuX3ymyEHtpN3g0vS+82NjnQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2064,7 +2064,7 @@
       "adminwebsite": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.10-pr-0663-0003, )",
+          "BookingsApi.Client": "[1.45.13-pr-0663-0010, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/RebookHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/RebookHearingTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using AdminWebsite.UnitTests.Helper;
+using Autofac.Extras.Moq;
+using BookingsApi.Client;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+
+namespace AdminWebsite.UnitTests.Controllers.HearingsController
+{
+    public class RebookHearingTests
+    {
+        private AutoMock _mocker;
+        private AdminWebsite.Controllers.HearingsController _controller;
+        
+        [SetUp]
+        public void Setup()
+        {
+            _mocker = AutoMock.GetLoose();
+            _controller = _mocker.Create<AdminWebsite.Controllers.HearingsController>();
+        }
+        
+        [Test]
+        public async Task Should_return_no_content_when_successful()
+        {
+            var hearingId = Guid.NewGuid();
+            _mocker.Mock<IBookingsApiClient>()
+                .Setup(x => x.RebookHearingAsync(hearingId))
+                .Verifiable();
+
+            var response = await _controller.RebookHearing(hearingId);
+
+            response.Should().BeOfType<NoContentResult>();
+            _mocker.Mock<IBookingsApiClient>()
+                .Verify(x => x.RebookHearingAsync(hearingId),
+                Times.Once());
+
+        }
+
+        [Test]
+        public async Task Should_pass_not_found_from_bookings_api()
+        {
+            var hearingId = Guid.NewGuid();
+            _mocker.Mock<IBookingsApiClient>().Setup(x => x.RebookHearingAsync(hearingId))
+                .Throws(ClientException.ForBookingsAPI(HttpStatusCode.NotFound));
+            
+            var response = await _controller.RebookHearing(hearingId);
+
+            response.Should().BeOfType<NotFoundObjectResult>();
+        }
+
+        [Test]
+        public async Task Should_pass_bad_request_from_bookings_api()
+        {
+            var hearingId = Guid.NewGuid();
+            _mocker.Mock<IBookingsApiClient>().Setup(x => x.RebookHearingAsync(hearingId))
+                .Throws(ClientException.ForBookingsAPI(HttpStatusCode.BadRequest));
+            
+            var response = await _controller.RebookHearing(hearingId);
+
+            response.Should().BeOfType<BadRequestObjectResult>();
+        }
+    }
+}

--- a/AdminWebsite/AdminWebsite.UnitTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.UnitTests/packages.lock.json
@@ -98,8 +98,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.10-pr-0663-0003",
-        "contentHash": "kf7BuTVUOdd4KGAmdxV1UY3u9Rp8UWtlu/jp3CCY4CCmpIpdGyBqaSsFMZs269838vjrk1d2mZbXKaiLJVu+uQ==",
+        "resolved": "1.45.13-pr-0663-0010",
+        "contentHash": "+0V3k1wIjlxAC6202hJL9q+Xb891tM6sOkW349TMKKoZ2RY027EKODPdVAdPdOeuX3ymyEHtpN3g0vS+82NjnQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1938,7 +1938,7 @@
       "adminwebsite": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.10-pr-0663-0003, )",
+          "BookingsApi.Client": "[1.45.13-pr-0663-0010, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite.UnitTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.UnitTests/packages.lock.json
@@ -98,8 +98,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.13-pr-0663-0010",
-        "contentHash": "+0V3k1wIjlxAC6202hJL9q+Xb891tM6sOkW349TMKKoZ2RY027EKODPdVAdPdOeuX3ymyEHtpN3g0vS+82NjnQ==",
+        "resolved": "1.45.15",
+        "contentHash": "EK0Iyd4i1LyoXw98tDRehbIl5iX23U4ucfwIcqcBVLa1AT7YsYtiR6LWCJi84vvvwnZjIh33ohmPlMDMg/lAyQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1938,7 +1938,7 @@
       "adminwebsite": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.13-pr-0663-0010, )",
+          "BookingsApi.Client": "[1.45.15, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite.UnitTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.UnitTests/packages.lock.json
@@ -98,8 +98,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.44.6",
-        "contentHash": "pr59SEWnlnkGyZmilLh+6JiUEZqLXn6iic5NVTEjO22VFs3Qij0RfZ2q+fotW2rk/tVcs0P2WGITt9kulBm5SQ==",
+        "resolved": "1.45.10-pr-0663-0003",
+        "contentHash": "kf7BuTVUOdd4KGAmdxV1UY3u9Rp8UWtlu/jp3CCY4CCmpIpdGyBqaSsFMZs269838vjrk1d2mZbXKaiLJVu+uQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1938,7 +1938,7 @@
       "adminwebsite": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.44.6, )",
+          "BookingsApi.Client": "[1.45.10-pr-0663-0003, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite/AdminWebsite.csproj
+++ b/AdminWebsite/AdminWebsite/AdminWebsite.csproj
@@ -31,7 +31,7 @@
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.45.10-pr-0663-0003" />
+    <PackageReference Include="BookingsApi.Client" Version="1.45.13-pr-0663-0010" />
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="7.0.3" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.51.0" />

--- a/AdminWebsite/AdminWebsite/AdminWebsite.csproj
+++ b/AdminWebsite/AdminWebsite/AdminWebsite.csproj
@@ -31,7 +31,7 @@
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.44.6" />
+    <PackageReference Include="BookingsApi.Client" Version="1.45.10-pr-0663-0003" />
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="7.0.3" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.51.0" />

--- a/AdminWebsite/AdminWebsite/AdminWebsite.csproj
+++ b/AdminWebsite/AdminWebsite/AdminWebsite.csproj
@@ -31,7 +31,7 @@
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.45.13-pr-0663-0010" />
+    <PackageReference Include="BookingsApi.Client" Version="1.45.15" />
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="7.0.3" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.51.0" />

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.spec.ts
@@ -29,6 +29,7 @@ import { ParticipantService } from '../services/participant.service';
 import { SummaryComponent } from './summary.component';
 import { FeatureFlagService } from '../../services/feature-flag.service';
 import { ResponseTestData } from 'src/app/testing/data/response-test-data';
+import { BookingStatusService } from 'src/app/services/booking-status-service';
 
 function initExistingHearingRequest(): HearingModel {
     const pat1 = new ParticipantModel();
@@ -115,6 +116,8 @@ videoHearingsServiceSpy = jasmine.createSpyObj<VideoHearingsService>('VideoHeari
 ]);
 const featureFlagSpy = jasmine.createSpyObj<FeatureFlagService>('FeatureFlagService', ['getFeatureFlagByName']);
 featureFlagSpy.getFeatureFlagByName.and.returnValue(of(true));
+const bookingStatusService = new BookingStatusService(videoHearingsServiceSpy);
+
 describe('SummaryComponent with valid request', () => {
     let component: SummaryComponent;
     let fixture: ComponentFixture<SummaryComponent>;
@@ -139,7 +142,8 @@ describe('SummaryComponent with valid request', () => {
                 { provide: Router, useValue: routerSpy },
                 { provide: Logger, useValue: loggerSpy },
                 { provide: RecordingGuardService, useValue: recordingGuardServiceSpy },
-                { provide: FeatureFlagService, useValue: featureFlagSpy }
+                { provide: FeatureFlagService, useValue: featureFlagSpy },
+                { provide: BookingStatusService, useValue: bookingStatusService }
             ],
             declarations: [
                 SummaryComponent,
@@ -568,7 +572,8 @@ describe('SummaryComponent  with invalid request', () => {
                 { provide: VideoHearingsService, useValue: videoHearingsServiceSpy },
                 { provide: Router, useValue: routerSpy },
                 { provide: Logger, useValue: loggerSpy },
-                { provide: FeatureFlagService, useValue: featureFlagSpy }
+                { provide: FeatureFlagService, useValue: featureFlagSpy },
+                { provide: BookingStatusService, useValue: bookingStatusService }
             ],
             imports: [RouterTestingModule],
             declarations: [
@@ -626,7 +631,8 @@ describe('SummaryComponent  with existing request', () => {
                 { provide: Router, useValue: routerSpy },
                 { provide: Logger, useValue: loggerSpy },
                 { provide: RecordingGuardService, useValue: recordingGuardServiceSpy },
-                { provide: FeatureFlagService, useValue: featureFlagSpy }
+                { provide: FeatureFlagService, useValue: featureFlagSpy },
+                { provide: BookingStatusService, useValue: bookingStatusService }
             ],
             imports: [RouterTestingModule],
             declarations: [
@@ -825,7 +831,8 @@ describe('SummaryComponent  with multi days request', () => {
         loggerSpy,
         recordingGuardServiceSpy,
         participantServiceSpy,
-        featureFlagServiceSpy
+        featureFlagServiceSpy,
+        bookingStatusService
     );
     component.participantsListComponent = new ParticipantListComponent(loggerSpy, videoHearingsServiceSpy);
     component.removeInterpreterPopupComponent = new RemoveInterpreterPopupComponent();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-import { Subscription, timer } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { EndpointModel } from 'src/app/common/model/endpoint.model';
 import { HearingRoles } from 'src/app/common/model/hearing-roles.model';
 import { ParticipantModel } from 'src/app/common/model/participant.model';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
@@ -20,6 +20,7 @@ import { ParticipantService } from '../services/participant.service';
 import { OtherInformationModel } from '../../common/model/other-information.model';
 import { first } from 'rxjs/operators';
 import { FeatureFlagService } from '../../services/feature-flag.service';
+import { BookingStatusService } from 'src/app/services/booking-status-service';
 
 @Component({
     selector: 'app-summary',
@@ -74,7 +75,8 @@ export class SummaryComponent implements OnInit, OnDestroy {
         private logger: Logger,
         private recordingGuardService: RecordingGuardService,
         private participantService: ParticipantService,
-        private featureService: FeatureFlagService
+        private featureService: FeatureFlagService,
+        private bookingStatusService: BookingStatusService
     ) {
         this.attemptingCancellation = false;
         this.showErrorSaving = false;
@@ -253,13 +255,8 @@ export class SummaryComponent implements OnInit, OnDestroy {
                 const hearingDetailsResponse = await this.hearingService.saveHearing(this.hearing);
 
                 if (this.judgeAssigned) {
-                    // Poll Video-Api for booking confirmation
-                    const schedule = timer(0, 5000).subscribe(async counter => {
-                        const hearingStatusResponse = await this.hearingService.getStatus(hearingDetailsResponse.id);
-                        if (hearingStatusResponse?.success || counter === 10) {
-                            schedule.unsubscribe();
-                            await this.processBooking(hearingDetailsResponse, hearingStatusResponse);
-                        }
+                    this.bookingStatusService.pollForStatus(hearingDetailsResponse.id).subscribe(async response => {
+                        await this.processBooking(hearingDetailsResponse, response);
                     });
                 } else {
                     await this.processMultiHearing(hearingDetailsResponse);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.html
@@ -55,15 +55,6 @@
             Cancel booking
           </button>
         </span>
-        <button
-          *ngIf="!hearing.isCreated && isConfirmationTimeValid && isVhOfficerAdmin && !hearing.hasBookingConfirmationFailed && judgeExists"
-          data-module="govuk-button"
-          class="govuk-button vh-mt20 hmcts-button--secondary"
-          id="confirm-button"
-          (click)="confirmHearing()"
-        >
-          Confirm booking
-        </button>
 
         <button
           *ngIf="hearing.hasBookingConfirmationFailed && canRetryConfirmation && judgeExists"

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.html
@@ -70,7 +70,7 @@
           data-module="govuk-button"
           class="govuk-button govuk-button--warning"
           id="retry-confirm-button"
-          (click)="confirmHearing()"
+          (click)="rebookHearing()"
         >
           Retry booking confirmation
         </button>

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.spec.ts
@@ -530,7 +530,7 @@ CY: 54321 (ID: 7777)`);
             component.isVhOfficerAdmin = true;
         });
 
-        it('should update display when rebook hearing succeeds', fakeAsync(async() => {
+        it('should update display when rebook hearing succeeds', fakeAsync(async () => {
             const getStatusResponse = new UpdateBookingStatusResponse({
                 success: true,
                 telephone_conference_id: '123'
@@ -542,11 +542,11 @@ CY: 54321 (ID: 7777)`);
                     resolve(conferencePhoneNumber);
                 })
             );
-    
+
             component.ngOnInit();
             await component.rebookHearing();
             tick(50000);
-    
+
             expect(videoHearingServiceSpy.rebookHearing).toHaveBeenCalledWith(component.hearingId);
             expect(videoHearingServiceSpy.getStatus).toHaveBeenCalledTimes(1);
             expect(component.telephoneConferenceId).toBe(getStatusResponse.telephone_conference_id);
@@ -554,26 +554,26 @@ CY: 54321 (ID: 7777)`);
             expect(component.conferencePhoneNumberWelsh).toBe(conferencePhoneNumber);
             expect(component.booking.isConfirmed).toBeTruthy();
             expect(component.showConfirming).toBeFalsy();
-    
+
             discardPeriodicTasks();
         }));
-    
-        it('should update display when rebook hearing fails', fakeAsync(async() => {
+
+        it('should update display when rebook hearing fails', fakeAsync(async () => {
             const getStatusResponse = new UpdateBookingStatusResponse({
                 success: false
             });
             videoHearingServiceSpy.getStatus.and.returnValue(Promise.resolve(getStatusResponse));
-    
+
             component.ngOnInit();
             await component.rebookHearing();
             tick(60000);
-    
+
             expect(videoHearingServiceSpy.rebookHearing).toHaveBeenCalledWith(component.hearingId);
             expect(videoHearingServiceSpy.getStatus).toHaveBeenCalledTimes(11);
             expect(component.showConfirmingFailed).toBeTruthy();
             expect(component.hearing.Status).toBe(UpdateBookingStatus.Failed);
             expect(component.showConfirming).toBeFalsy();
-    
+
             discardPeriodicTasks();
         }));
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.spec.ts
@@ -24,6 +24,7 @@ import { UserIdentityService } from '../../services/user-identity.service';
 import { VideoHearingsService } from '../../services/video-hearings.service';
 import { PageUrls } from '../../shared/page-url.constants';
 import { BookingDetailsComponent } from './booking-details.component';
+import { BookingStatusService } from 'src/app/services/booking-status-service';
 
 let component: BookingDetailsComponent;
 let videoHearingServiceSpy: jasmine.SpyObj<VideoHearingsService>;
@@ -203,6 +204,7 @@ describe('BookingDetailsComponent', () => {
     returnUrlServiceSpy = jasmine.createSpyObj<ReturnUrlService>('ReturnUrlService', ['popUrl', 'setUrl']);
 
     const defaultUpdateBookingStatusResponse = new UpdateBookingStatusResponse({ success: true, telephone_conference_id: '1234' });
+    const bookingStatusService = new BookingStatusService(videoHearingServiceSpy);
 
     beforeEach(() => {
         videoHearingServiceSpy.getHearingById.and.returnValue(of(hearingResponse));
@@ -223,7 +225,8 @@ describe('BookingDetailsComponent', () => {
             bookingServiceSpy,
             bookingPersistServiceSpy,
             loggerSpy,
-            returnUrlServiceSpy
+            returnUrlServiceSpy,
+            bookingStatusService
         );
         component.hearingId = '1';
     });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.spec.ts
@@ -324,11 +324,6 @@ describe('BookingDetailsComponent', () => {
         component.setTimeObserver();
         expect(component.isConfirmationTimeValid).toBeTruthy();
     }));
-    it('should confirm booking', () => {
-        component.isVhOfficerAdmin = true;
-        component.confirmHearing();
-        expect(videoHearingServiceSpy.getHearingById).toHaveBeenCalled();
-    });
     it('should show that user role is Vh office admin', () => {
         const profile = new UserProfileResponse({ is_vh_officer_administrator_role: true });
         component.getUserRole(profile);
@@ -339,15 +334,6 @@ describe('BookingDetailsComponent', () => {
         component.getUserRole(profile);
         expect(component.isVhOfficerAdmin).toBeFalsy();
     });
-    it('should not confirm booking if not the VH officer admin role', fakeAsync(() => {
-        component.ngOnInit();
-        tick(1000);
-        const initialStatus = component.booking.status;
-        component.isVhOfficerAdmin = false;
-        component.confirmHearing();
-        expect(component.booking.status).toBe(initialStatus);
-        discardPeriodicTasks();
-    }));
     it('should persist status in the model', () => {
         component.booking = null;
         component.persistStatus(UpdateBookingStatus.Created);
@@ -382,23 +368,6 @@ describe('BookingDetailsComponent', () => {
         component.navigateBack();
         expect(routerSpy.navigateByUrl).toHaveBeenCalledWith(PageUrls.BookingsList);
     });
-    it('should not show pop up if the confirm not failed', () => {
-        videoHearingServiceSpy.updateBookingStatus.and.returnValue(of(new UpdateBookingStatusResponse({ success: true })));
-        component.isVhOfficerAdmin = true;
-        component.confirmHearing();
-        expect(component.showConfirmingFailed).toBeFalsy();
-    });
-    it('should show pop up if the confirm failed', fakeAsync(() => {
-        component.ngOnInit();
-        tick(1000);
-        videoHearingServiceSpy.updateBookingStatus.and.returnValue(of(new UpdateBookingStatusResponse({ success: false })));
-        component.hearing.Status = '';
-        component.isVhOfficerAdmin = true;
-        component.confirmHearing();
-        tick(1000);
-        discardPeriodicTasks();
-        expect(component.showConfirmingFailed).toBeTruthy();
-    }));
     it('should hide pop up if the close confirm failed ok button was clicked', () => {
         component.showConfirmingFailed = true;
         component.closeConfirmFailed();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import * as moment from 'moment';
-import { interval, lastValueFrom, Subscription, timer } from 'rxjs';
+import { interval, lastValueFrom, Subscription } from 'rxjs';
 import { ReturnUrlService } from 'src/app/services/return-url.service';
 import { BookingsDetailsModel } from '../../common/model/bookings-list.model';
 import { HearingModel } from '../../common/model/hearing.model';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.ts
@@ -12,7 +12,6 @@ import { BookingPersistService } from '../../services/bookings-persist.service';
 import {
     BookingStatus,
     HearingDetailsResponse,
-    RebookHearingRequest,
     UpdateBookingStatus,
     UpdateBookingStatusRequest,
     UpdateBookingStatusResponse,
@@ -181,9 +180,8 @@ export class BookingDetailsComponent implements OnInit, OnDestroy {
     async rebookHearing() {
         this.showConfirming = true;
         const hearingId = this.hearingId;
-        const request = new RebookHearingRequest({ is_multi_day_hearing: this.booking.multiDays ?? false });
-        
-        await this.videoHearingService.rebookHearing(hearingId, request);
+
+        await this.videoHearingService.rebookHearing(hearingId);
 
         // Poll Video-Api for booking confirmation
         const schedule = timer(0, 5000).subscribe(async counter => {
@@ -224,7 +222,7 @@ export class BookingDetailsComponent implements OnInit, OnDestroy {
             const updateBookingStatusResponse = await lastValueFrom(
                 this.videoHearingService.updateBookingStatus(this.hearingId, updateBookingStatus)
             );
-            
+
             await this.updateHearingStatusDisplay(updateBookingStatusResponse, status);
         } catch (error) {
             if (status === UpdateBookingStatus.Cancelled) {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.ts
@@ -178,6 +178,11 @@ export class BookingDetailsComponent implements OnInit, OnDestroy {
     }
 
     async rebookHearing() {
+        if (!this.isVhOfficerAdmin) {
+            this.logger.warn(`${this.loggerPrefix} Cannot rebook hearing - user is not a Vh Officer Admin`);
+            return;
+        }
+
         this.showConfirming = true;
         const hearingId = this.hearingId;
 
@@ -188,16 +193,14 @@ export class BookingDetailsComponent implements OnInit, OnDestroy {
             const hearingStatusResponse = await this.videoHearingService.getStatus(hearingId);
             if (hearingStatusResponse?.success || counter === 10) {
                 schedule.unsubscribe();
-                await this.processBooking(hearingStatusResponse);
+                await this.getStatusPollOnComplete(hearingStatusResponse);
             }
         });
     }
 
-    async processBooking(hearingStatusResponse: UpdateBookingStatusResponse): Promise<void> {
+    async getStatusPollOnComplete(hearingStatusResponse: UpdateBookingStatusResponse): Promise<void> {
         let updateBookingStatus: UpdateBookingStatus = UpdateBookingStatus.Failed;
         if (hearingStatusResponse?.success) {
-            // TODO handle this
-            //await this.processMultiHearing(hearingDetailsResponse);
             updateBookingStatus = UpdateBookingStatus.Created;
         }
         await this.updateHearingStatusDisplay(hearingStatusResponse, updateBookingStatus);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/booking-details/booking-details.component.ts
@@ -173,12 +173,6 @@ export class BookingDetailsComponent implements OnInit, OnDestroy {
         this.showCancelBooking = true;
     }
 
-    confirmHearing() {
-        if (this.isVhOfficerAdmin) {
-            this.updateHearingStatus(UpdateBookingStatus.Created, '');
-        }
-    }
-
     async rebookHearing() {
         if (!this.isVhOfficerAdmin) {
             this.logger.warn(`${this.loggerPrefix} Cannot rebook hearing - user is not a Vh Officer Admin`);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/booking-status-service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/booking-status-service.ts
@@ -1,0 +1,28 @@
+import { Observable, timer } from 'rxjs';
+import { VideoHearingsService } from './video-hearings.service';
+import { UpdateBookingStatusResponse } from './clients/api-client';
+
+export class BookingStatusService {
+    constructor(private videoHearingService: VideoHearingsService) {}
+
+    pollForStatus(hearingId: string): Observable<UpdateBookingStatusResponse> {
+        const maxAttempts = 10;
+        const interval = 5000;
+
+        return new Observable<UpdateBookingStatusResponse>(subscriber => {
+            const schedule = timer(0, interval).subscribe(async (counter: number) => {
+                try {
+                    const statusResponse = await this.videoHearingService.getStatus(hearingId);
+                    if (statusResponse?.success || counter === maxAttempts) {
+                        schedule.unsubscribe();
+                        subscriber.next(statusResponse);
+                        subscriber.complete();
+                    }
+                } catch (error) {
+                    schedule.unsubscribe();
+                    subscriber.error(error);
+                }
+            });
+        });
+    }
+}

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/booking-status-service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/booking-status-service.ts
@@ -1,7 +1,11 @@
 import { Observable, timer } from 'rxjs';
 import { VideoHearingsService } from './video-hearings.service';
 import { UpdateBookingStatusResponse } from './clients/api-client';
+import { Injectable } from '@angular/core';
 
+@Injectable({
+    providedIn: 'root'
+})
 export class BookingStatusService {
     constructor(private videoHearingService: VideoHearingsService) {}
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/clients/api-client.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/clients/api-client.ts
@@ -1060,24 +1060,20 @@ export class BHClient extends ApiClientBase {
     }
 
     /**
-     * @param body (optional)
-     * @return Success
+     * Rebook an existing hearing with a booking status of Failed
+     * @param hearingId Id of the hearing with a status of Failed
+     * @return No Content
      */
-    rebookHearing(hearingId: string, body: RebookHearingRequest | undefined): Observable<void> {
+    rebookHearing(hearingId: string): Observable<void> {
         let url_ = this.baseUrl + '/api/hearings/{hearingId}/conferences';
         if (hearingId === undefined || hearingId === null) throw new Error("The parameter 'hearingId' must be defined.");
         url_ = url_.replace('{hearingId}', encodeURIComponent('' + hearingId));
         url_ = url_.replace(/[?&]$/, '');
 
-        const content_ = JSON.stringify(body);
-
         let options_: any = {
-            body: content_,
             observe: 'response',
             responseType: 'blob',
-            headers: new HttpHeaders({
-                'Content-Type': 'application/json-patch+json'
-            })
+            headers: new HttpHeaders({})
         };
 
         return _observableFrom(this.transformOptions(options_))
@@ -1128,7 +1124,7 @@ export class BHClient extends ApiClientBase {
                     return throwException('Server Error', status, _responseText, _headers, result500);
                 })
             );
-        } else if (status === 200) {
+        } else if (status === 204) {
             return blobToText(responseBlob).pipe(
                 _observableMergeMap((_responseText: string) => {
                     return _observableOf(null as any);
@@ -1148,7 +1144,7 @@ export class BHClient extends ApiClientBase {
                 _observableMergeMap((_responseText: string) => {
                     let result400: any = null;
                     let resultData400 = _responseText === '' ? null : JSON.parse(_responseText, this.jsonParseReviver);
-                    result400 = ProblemDetails.fromJS(resultData400);
+                    result400 = ValidationProblemDetails.fromJS(resultData400);
                     return throwException('Bad Request', status, _responseText, _headers, result400);
                 })
             );
@@ -7706,44 +7702,6 @@ export interface IParticipantRequest {
     hearing_role_name?: string | undefined;
     representee?: string | undefined;
     organisation_name?: string | undefined;
-}
-
-export class RebookHearingRequest implements IRebookHearingRequest {
-    is_multi_day_hearing?: boolean;
-
-    constructor(data?: IRebookHearingRequest) {
-        if (data) {
-            for (var property in data) {
-                if (data.hasOwnProperty(property)) (<any>this)[property] = (<any>data)[property];
-            }
-        }
-        if (!data) {
-            this.is_multi_day_hearing = false;
-        }
-    }
-
-    init(_data?: any) {
-        if (_data) {
-            this.is_multi_day_hearing = _data['is_multi_day_hearing'] !== undefined ? _data['is_multi_day_hearing'] : false;
-        }
-    }
-
-    static fromJS(data: any): RebookHearingRequest {
-        data = typeof data === 'object' ? data : {};
-        let result = new RebookHearingRequest();
-        result.init(data);
-        return result;
-    }
-
-    toJSON(data?: any) {
-        data = typeof data === 'object' ? data : {};
-        data['is_multi_day_hearing'] = this.is_multi_day_hearing;
-        return data;
-    }
-}
-
-export interface IRebookHearingRequest {
-    is_multi_day_hearing?: boolean;
 }
 
 export class RestoreJusticeUserRequest implements IRestoreJusticeUserRequest {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.spec.ts
@@ -36,7 +36,8 @@ describe('Video hearing service', () => {
             'getTelephoneConferenceIdById',
             'getConfigSettings',
             'getUserList',
-            'getAllocationForHearing'
+            'getAllocationForHearing',
+            'rebookHearing'
         ]);
         service = new VideoHearingsService(clientApiSpy);
     });
@@ -515,6 +516,13 @@ describe('Video hearing service', () => {
         const model = service.mapLinkedParticipantResponseToLinkedParticipantModel(linkedParticipants);
         expect(model[0].linkType).toEqual(linkedParticipant.type);
         expect(model[0].linkedParticipantId).toEqual(linkedParticipant.linked_id);
+    });
+
+    it('should rebook hearing', async () => {
+        clientApiSpy.rebookHearing.and.returnValue(of(null));
+
+        await service.rebookHearing('hearingId');
+        expect(clientApiSpy.rebookHearing).toHaveBeenCalled();
     });
 
     describe('isConferenceClosed', () => {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
@@ -25,9 +25,7 @@ import {
     LinkedParticipantResponse,
     LinkedParticipant,
     BookingStatus,
-    AllocatedCsoResponse,
-    RebookHearingRequest
-} from './clients/api-client';
+    AllocatedCsoResponse} from './clients/api-client';
 import { HearingModel } from '../common/model/hearing.model';
 import { CaseModel } from '../common/model/case.model';
 import { ParticipantModel } from '../common/model/participant.model';
@@ -186,8 +184,8 @@ export class VideoHearingsService {
         return await lastValueFrom(this.bhClient.cloneHearing(hearingId, request));
     }
 
-    rebookHearing(hearingId: string, request: RebookHearingRequest): Promise<void> {
-        return lastValueFrom(this.bhClient.rebookHearing(hearingId, request));
+    rebookHearing(hearingId: string): Promise<void> {
+        return lastValueFrom(this.bhClient.rebookHearing(hearingId));
     }
 
     updateHearing(booking: HearingModel): Observable<HearingDetailsResponse> {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
@@ -25,7 +25,8 @@ import {
     LinkedParticipantResponse,
     LinkedParticipant,
     BookingStatus,
-    AllocatedCsoResponse} from './clients/api-client';
+    AllocatedCsoResponse
+} from './clients/api-client';
 import { HearingModel } from '../common/model/hearing.model';
 import { CaseModel } from '../common/model/case.model';
 import { ParticipantModel } from '../common/model/participant.model';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
@@ -25,7 +25,8 @@ import {
     LinkedParticipantResponse,
     LinkedParticipant,
     BookingStatus,
-    AllocatedCsoResponse
+    AllocatedCsoResponse,
+    RebookHearingRequest
 } from './clients/api-client';
 import { HearingModel } from '../common/model/hearing.model';
 import { CaseModel } from '../common/model/case.model';
@@ -183,6 +184,10 @@ export class VideoHearingsService {
 
     async cloneMultiHearings(hearingId: string, request: MultiHearingRequest): Promise<void> {
         return await lastValueFrom(this.bhClient.cloneHearing(hearingId, request));
+    }
+
+    rebookHearing(hearingId: string, request: RebookHearingRequest): Promise<void> {
+        return lastValueFrom(this.bhClient.rebookHearing(hearingId, request));
     }
 
     updateHearing(booking: HearingModel): Observable<HearingDetailsResponse> {

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -108,6 +108,18 @@ namespace AdminWebsite.Controllers
             }
         }
 
+        [HttpPost("{hearingId}/conferences")]
+        [SwaggerOperation(OperationId = "RebookHearing")]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.NotFound)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> RebookHearing(Guid hearingId, RebookHearingRequest request)
+        {
+            await _bookingsApiClient.RebookHearingAsync(hearingId, request);
+
+            return Ok();
+        }
+
         /// <summary>
         ///     Clone hearings with the details of a given hearing on given dates
         /// </summary>

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -108,16 +108,33 @@ namespace AdminWebsite.Controllers
             }
         }
 
+        /// <summary>
+        /// Rebook an existing hearing with a booking status of Failed
+        /// </summary>
+        /// <param name="hearingId">Id of the hearing with a status of Failed</param>
+        /// <returns></returns>
         [HttpPost("{hearingId}/conferences")]
         [SwaggerOperation(OperationId = "RebookHearing")]
-        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
-        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-        public async Task<IActionResult> RebookHearing(Guid hearingId, RebookHearingRequest request)
+        [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> RebookHearing(Guid hearingId)
         {
-            await _bookingsApiClient.RebookHearingAsync(hearingId, request);
-
-            return Ok();
+            try
+            {
+                await _bookingsApiClient.RebookHearingAsync(hearingId);
+                
+                return NoContent();
+            }
+            catch (BookingsApiException e)
+            {
+                _logger.LogError(e,
+                    "There was a problem rebooking the hearing. Status Code {StatusCode} - Message {Message}",
+                    e.StatusCode, e.Response);
+                if (e.StatusCode == (int)HttpStatusCode.NotFound) return NotFound(e.Response);
+                if (e.StatusCode == (int)HttpStatusCode.BadRequest) return BadRequest(e.Response);
+                throw;
+            }
         }
 
         /// <summary>

--- a/AdminWebsite/AdminWebsite/packages.lock.json
+++ b/AdminWebsite/AdminWebsite/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.45.13-pr-0663-0010, )",
-        "resolved": "1.45.13-pr-0663-0010",
-        "contentHash": "+0V3k1wIjlxAC6202hJL9q+Xb891tM6sOkW349TMKKoZ2RY027EKODPdVAdPdOeuX3ymyEHtpN3g0vS+82NjnQ==",
+        "requested": "[1.45.15, )",
+        "resolved": "1.45.15",
+        "contentHash": "EK0Iyd4i1LyoXw98tDRehbIl5iX23U4ucfwIcqcBVLa1AT7YsYtiR6LWCJi84vvvwnZjIh33ohmPlMDMg/lAyQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }

--- a/AdminWebsite/AdminWebsite/packages.lock.json
+++ b/AdminWebsite/AdminWebsite/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.45.10-pr-0663-0003, )",
-        "resolved": "1.45.10-pr-0663-0003",
-        "contentHash": "kf7BuTVUOdd4KGAmdxV1UY3u9Rp8UWtlu/jp3CCY4CCmpIpdGyBqaSsFMZs269838vjrk1d2mZbXKaiLJVu+uQ==",
+        "requested": "[1.45.13-pr-0663-0010, )",
+        "resolved": "1.45.13-pr-0663-0010",
+        "contentHash": "+0V3k1wIjlxAC6202hJL9q+Xb891tM6sOkW349TMKKoZ2RY027EKODPdVAdPdOeuX3ymyEHtpN3g0vS+82NjnQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }

--- a/AdminWebsite/AdminWebsite/packages.lock.json
+++ b/AdminWebsite/AdminWebsite/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.6, )",
-        "resolved": "1.44.6",
-        "contentHash": "pr59SEWnlnkGyZmilLh+6JiUEZqLXn6iic5NVTEjO22VFs3Qij0RfZ2q+fotW2rk/tVcs0P2WGITt9kulBm5SQ==",
+        "requested": "[1.45.10-pr-0663-0003, )",
+        "resolved": "1.45.10-pr-0663-0003",
+        "contentHash": "kf7BuTVUOdd4KGAmdxV1UY3u9Rp8UWtlu/jp3CCY4CCmpIpdGyBqaSsFMZs269838vjrk1d2mZbXKaiLJVu+uQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }

--- a/charts/vh-admin-web/values.dev.template.yaml
+++ b/charts/vh-admin-web/values.dev.template.yaml
@@ -9,3 +9,4 @@ java:
     AZUREAD__REDIRECTURI: https://${SERVICE_FQDN}/home
     DOM1__POSTLOGOUTREDIRECTURI: https://${SERVICE_FQDN}/logout
     DOM1__REDIRECTURI: https://${SERVICE_FQDN}/home
+    VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-663.dev.platform.hmcts.net/

--- a/charts/vh-admin-web/values.dev.template.yaml
+++ b/charts/vh-admin-web/values.dev.template.yaml
@@ -9,4 +9,3 @@ java:
     AZUREAD__REDIRECTURI: https://${SERVICE_FQDN}/home
     DOM1__POSTLOGOUTREDIRECTURI: https://${SERVICE_FQDN}/logout
     DOM1__REDIRECTURI: https://${SERVICE_FQDN}/home
-    VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-663.dev.platform.hmcts.net/


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9950


### Change description ###
Changes the functionality of the retry button for a failed booking from confirmHearing to rebookHearing. This will attempt to re-create the conference in video API (along with any users that failed to create) and then poll the booking status to verify that it was created.

The polling is the same as what we use on the summary component to check whether the booking was initially created successfully, so it has been refactored into a common booking status service.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
