### PR TITLE
VIH-10041 Work hours upload error message handling to prevent wrong message being show

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/upload-work-hours/upload-work-hours.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/upload-work-hours/upload-work-hours.component.html
@@ -31,7 +31,14 @@
           type="file"
           accept=".CSV"
         />
-        <button class="govuk-button govuk-!-margin-left-6" data-module="govuk-button" (click)="uploadWorkingHours()">Upload</button>
+        <button
+          class="govuk-button govuk-!-margin-left-6"
+          data-module="govuk-button"
+          (click)="uploadWorkingHours()"
+          [disabled]="disableWorkHoursButton"
+        >
+          Upload
+        </button>
       </div>
     </div>
     <ng-container
@@ -122,7 +129,14 @@
           type="file"
           accept=".CSV"
         />
-        <button class="govuk-button govuk-!-margin-left-6" data-module="govuk-button" (click)="uploadNonWorkingHours()">Upload</button>
+        <button
+          class="govuk-button govuk-!-margin-left-6"
+          data-module="govuk-button"
+          (click)="uploadNonWorkingHours()"
+          [disabled]="disableNonWorkHoursButton"
+        >
+          Upload
+        </button>
       </div>
     </div>
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/upload-work-hours/upload-work-hours.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/upload-work-hours/upload-work-hours.component.spec.ts
@@ -70,6 +70,31 @@ describe('UploadWorkHoursComponent', () => {
             expect(resetErrorsSpy).toHaveBeenCalled();
         });
 
+        it('should disable upload button for work hours if file is invalid', () => {
+            const resetErrorsSpy = spyOn(component, 'resetWorkingHoursMessages');
+            workHoursProcessorSpy.isFileFormatValild.and.returnValue(false);
+            const file = new File([''], 'filename.xlsx', { type: 'xlsx' });
+
+            component.handleFileInput(file, FileType.UploadWorkingHours);
+
+            expect(component.disableWorkHoursButton).toBe(true);
+            expect(resetErrorsSpy).toHaveBeenCalled();
+            expect(component.workingHoursFileValidationErrors.length).toBeGreaterThan(0);
+        });
+
+        it('should disable upload button for non work hours if file is invalid', () => {
+            const resetErrorsSpy = spyOn(component, 'resetNonWorkingHoursMessages');
+            component.disableNonWorkHoursButton = false;
+            workHoursProcessorSpy.isFileFormatValild.and.returnValue(false);
+            const file = new File([''], 'filename.xlsx', { type: 'xlsx' });
+
+            component.handleFileInput(file, FileType.UploadNonWorkingHours);
+
+            expect(component.disableNonWorkHoursButton).toBe(true);
+            expect(resetErrorsSpy).toHaveBeenCalled();
+            expect(component.nonWorkingHoursFileValidationErrors.length).toBeGreaterThan(0);
+        });
+
         it('should not assign non-working hours file if file is null', () => {
             const resetErrorsSpy = spyOn(component, 'resetNonWorkingHoursMessages');
             const file = new File([''], 'filename.csv', { type: 'text/csv' });
@@ -82,6 +107,8 @@ describe('UploadWorkHoursComponent', () => {
         });
 
         it(`should set errors when maximum working hours file size is exceeded`, () => {
+            component.disableWorkHoursButton = false;
+            const resetErrorsSpy = spyOn(component, 'resetWorkingHoursMessages');
             const file = new File([''], 'filename.csv', { type: 'text/csv' });
             Object.defineProperty(file, 'size', { value: 2000001 });
             workHoursProcessorSpy.isFileTooBig.and.returnValue(true);
@@ -89,9 +116,13 @@ describe('UploadWorkHoursComponent', () => {
             component.handleFileInput(file, FileType.UploadWorkingHours);
 
             expect(component.workingHoursFileValidationErrors[0]).toBe('File cannot be larger than 200kb');
+            expect(component.disableWorkHoursButton).toBe(true);
+            expect(resetErrorsSpy).toHaveBeenCalled();
         });
 
         it(`should set errors when maximum non-working hours file size is exceeded`, () => {
+            component.disableNonWorkHoursButton = false;
+            const resetErrorsSpy = spyOn(component, 'resetNonWorkingHoursMessages');
             const file = new File([''], 'filename.csv', { type: 'text/csv' });
             Object.defineProperty(file, 'size', { value: 2000001 });
             workHoursProcessorSpy.isFileTooBig.and.returnValue(true);
@@ -99,6 +130,8 @@ describe('UploadWorkHoursComponent', () => {
             component.handleFileInput(file, FileType.UploadNonWorkingHours);
 
             expect(component.nonWorkingHoursFileValidationErrors[0]).toBe('File cannot be larger than 200kb');
+            expect(component.disableNonWorkHoursButton).toBe(true);
+            expect(resetErrorsSpy).toHaveBeenCalled();
         });
     });
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/upload-work-hours/upload-work-hours.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/upload-work-hours/upload-work-hours.component.ts
@@ -27,7 +27,7 @@ export class UploadWorkHoursComponent {
 
     constructor(private workHoursProcessor: WorkHoursFileProcessorService) {}
 
-    handleFileInput(file: File, fileType) {
+    handleFileInput(file: File, fileType: FileType) {
         if (!file) {
             this.handleFileInputCancel(fileType);
             return;
@@ -35,42 +35,18 @@ export class UploadWorkHoursComponent {
 
         if (!this.workHoursProcessor.isFileFormatValild(file)) {
             const message = `File format is not supported, Supported file format is .CSV`;
-            if (fileType === FileType.UploadNonWorkingHours) {
-                this.disableNonWorkHoursButton = true;
-                this.resetNonWorkingHoursMessages();
-                this.nonWorkingHoursFileValidationErrors.push(message);
-            } else {
-                this.disableWorkHoursButton = true;
-                this.resetWorkingHoursMessages();
-                this.workingHoursFileValidationErrors.push(message);
-            }
+            this.handleFileInputError(fileType, message);
             return;
         } else {
-            if (fileType === FileType.UploadWorkingHours) {
-                this.disableWorkHoursButton = false;
-            } else {
-                this.disableNonWorkHoursButton = false;
-            }
+            this.reenableUploadButton(fileType);
         }
 
         if (this.workHoursProcessor.isFileTooBig(file)) {
             const message = `File cannot be larger than ${this.workHoursProcessor.maxFileUploadSize / 1000}kb`;
-            if (fileType === FileType.UploadNonWorkingHours) {
-                this.disableNonWorkHoursButton = true;
-                this.resetNonWorkingHoursMessages();
-                this.nonWorkingHoursFileValidationErrors.push(message);
-            } else {
-                this.disableWorkHoursButton = true;
-                this.resetWorkingHoursMessages();
-                this.workingHoursFileValidationErrors.push(message);
-            }
+            this.handleFileInputError(fileType, message);
             return;
         } else {
-            if (fileType === FileType.UploadWorkingHours) {
-                this.disableWorkHoursButton = false;
-            } else {
-                this.disableNonWorkHoursButton = false;
-            }
+            this.reenableUploadButton(fileType);
         }
 
         if (fileType === FileType.UploadWorkingHours) {
@@ -164,5 +140,25 @@ export class UploadWorkHoursComponent {
 
         const reader = this.readFile(this.nonWorkingHoursFile);
         reader.onload = e => this.readNonWorkAvailability(e.target.result as string);
+    }
+
+    private handleFileInputError(fileType: FileType, message: string) {
+        if (fileType === FileType.UploadNonWorkingHours) {
+            this.disableNonWorkHoursButton = true;
+            this.resetNonWorkingHoursMessages();
+            this.nonWorkingHoursFileValidationErrors.push(message);
+        } else {
+            this.disableWorkHoursButton = true;
+            this.resetWorkingHoursMessages();
+            this.workingHoursFileValidationErrors.push(message);
+        }
+    }
+
+    private reenableUploadButton(fileType: FileType) {
+        if (fileType === FileType.UploadWorkingHours) {
+            this.disableWorkHoursButton = false;
+        } else {
+            this.disableNonWorkHoursButton = false;
+        }
     }
 }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/upload-work-hours/upload-work-hours.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/upload-work-hours/upload-work-hours.component.ts
@@ -22,10 +22,12 @@ export class UploadWorkHoursComponent {
 
     public workingHoursFile: File | null = null;
     public nonWorkingHoursFile: File | null = null;
+    public disableNonWorkHoursButton: boolean;
+    public disableWorkHoursButton: boolean;
 
     constructor(private workHoursProcessor: WorkHoursFileProcessorService) {}
 
-    handleFileInput(file: File, fileType: FileType) {
+    handleFileInput(file: File, fileType) {
         if (!file) {
             this.handleFileInputCancel(fileType);
             return;
@@ -34,21 +36,41 @@ export class UploadWorkHoursComponent {
         if (!this.workHoursProcessor.isFileFormatValild(file)) {
             const message = `File format is not supported, Supported file format is .CSV`;
             if (fileType === FileType.UploadNonWorkingHours) {
+                this.disableNonWorkHoursButton = true;
+                this.resetNonWorkingHoursMessages();
                 this.nonWorkingHoursFileValidationErrors.push(message);
             } else {
+                this.disableWorkHoursButton = true;
+                this.resetWorkingHoursMessages();
                 this.workingHoursFileValidationErrors.push(message);
             }
             return;
+        } else {
+            if (fileType === FileType.UploadWorkingHours) {
+                this.disableWorkHoursButton = false;
+            } else {
+                this.disableNonWorkHoursButton = false;
+            }
         }
 
         if (this.workHoursProcessor.isFileTooBig(file)) {
             const message = `File cannot be larger than ${this.workHoursProcessor.maxFileUploadSize / 1000}kb`;
             if (fileType === FileType.UploadNonWorkingHours) {
+                this.disableNonWorkHoursButton = true;
+                this.resetNonWorkingHoursMessages();
                 this.nonWorkingHoursFileValidationErrors.push(message);
             } else {
+                this.disableWorkHoursButton = true;
+                this.resetWorkingHoursMessages();
                 this.workingHoursFileValidationErrors.push(message);
             }
             return;
+        } else {
+            if (fileType === FileType.UploadWorkingHours) {
+                this.disableWorkHoursButton = false;
+            } else {
+                this.disableNonWorkHoursButton = false;
+            }
         }
 
         if (fileType === FileType.UploadWorkingHours) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-10041

### Description ###
 Added a reset to errors before displaying a new size or invalid file error. Also disabled the upload button if one of these happens, as if you click it, will upload the previous file and potentially show a success message on an invalid file.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
