### PR TITLE
VIH-10150 Fix for audio recording being set back to true when adding interpreter to Crime Crown Court

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.spec.ts
@@ -308,6 +308,11 @@ describe('SummaryComponent with valid request', () => {
         component.ngOnInit();
         expect(component.hearing.audio_recording_required).toBe(false);
     });
+    it('should set audio recording to false if case type is Crime Crown Court', () => {
+        component.hearing.case_type = component.constants.CaseTypes.CrimeCrownCourt;
+        component.ngOnInit();
+        expect(component.hearing.audio_recording_required).toBe(false);
+    });
     it('should set audio recording to false if case type is Crime Crown Court and an interpreter is present', () => {
         component.hearing.case_type = component.constants.CaseTypes.CrimeCrownCourt;
         component.interpreterPresent = true;

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.spec.ts
@@ -308,6 +308,13 @@ describe('SummaryComponent with valid request', () => {
         component.ngOnInit();
         expect(component.hearing.audio_recording_required).toBe(false);
     });
+    it('should set audio recording to false if case type is Crime Crown Court and an interpreter is present', () => {
+        component.hearing.case_type = component.constants.CaseTypes.CrimeCrownCourt;
+        component.interpreterPresent = true;
+        component.isAudioRecordingRequired();
+        component.ngOnInit();
+        expect(component.hearing.audio_recording_required).toBe(false);
+    });
     it('should display valid court address when room number is empty', () => {
         component.hearing.court_room = '';
         component.ngOnInit();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
@@ -117,7 +117,10 @@ export class SummaryComponent implements OnInit, OnDestroy {
 
     isAudioRecordingRequired(): boolean {
         // CACD hearings should always have recordings set to off
-        if (this.caseType === this.constants.CaseTypes.CourtOfAppealCriminalDivision) {
+        if (
+            this.caseType === this.constants.CaseTypes.CourtOfAppealCriminalDivision ||
+            this.caseType === this.constants.CaseTypes.CrimeCrownCourt
+        ) {
             return false;
         }
         // Hearings with an interpreter should always have recording set to on

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/summary/summary.component.ts
@@ -172,7 +172,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
             }
             this.hearing.participants.splice(indexOfParticipant, 1);
             this.removeLinkedParticipant(this.selectedParticipantEmail);
-            this.hearing = Object.assign({}, this.hearing);
+            this.hearing = { ...this.hearing };
             this.hearingService.updateHearingRequest(this.hearing);
             this.hearingService.setBookingHasChanged(true);
             this.bookingService.removeParticipantEmail();
@@ -436,7 +436,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
         }
         this.participantService.removeParticipant(this.hearing, this.selectedParticipantEmail);
         this.removeLinkedParticipant(this.selectedParticipantEmail);
-        this.hearing = Object.assign({}, this.hearing);
+        this.hearing = { ...this.hearing };
         this.hearingService.updateHearingRequest(this.hearing);
         this.hearingService.setBookingHasChanged(true);
         this.bookingService.removeParticipantEmail();

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
@@ -84,7 +84,7 @@ export const Constants = {
         UserRestored: 'Changes saved successfully.'
     },
     OtherParticipantRoles: ['Staff Member', 'Observer', 'Panel Member', 'Winger'],
-    CaseTypes: { CourtOfAppealCriminalDivision: 'Court of Appeal Criminal Division' }
+    CaseTypes: { CourtOfAppealCriminalDivision: 'Court of Appeal Criminal Division', CrimeCrownCourt: 'Crime Crown Court' }
 };
 
 /*


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-10150


### Change description ###
Fixes an issue where the option to record audio is being set to true for the Crime Crown Court case type when adding an interpreter (it should always be false).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
