### PR TITLE
VIH-10152 Audio recording required being changed to true on edit for Crime Crown Court and CACD

### DIFF
--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/HearingUpdateRequestMapperTest.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/HearingUpdateRequestMapperTest.cs
@@ -46,28 +46,5 @@ namespace AdminWebsite.UnitTests.Mappers
             result.QuestionnaireNotRequired.Should().Be(_newParticipantRequest.QuestionnaireNotRequired);
             result.AudioRecordingRequired.Should().Be(_newParticipantRequest.AudioRecordingRequired);
         }
-
-        [Test]
-        public void Should_map_property_AudioRecordingRequired_with_true_value_for_when_linkedParticipant_is_interpreter()
-        {
-            _newParticipantRequest.Participants = new List<EditParticipantRequest>
-            {
-                new EditParticipantRequest
-                {
-                    LinkedParticipants = new List<LinkedParticipant>
-                    {
-                        new LinkedParticipant
-                        {
-                            Id = Guid.NewGuid(),
-                            LinkedId = Guid.NewGuid(),
-                            ParticipantId = Guid.NewGuid(),
-                            Type = LinkedParticipantType.Interpreter
-                        }
-                    }
-                }
-            };
-            var result = HearingUpdateRequestMapper.MapTo(_newParticipantRequest, _username);
-            result.AudioRecordingRequired.Should().BeTrue();
-        }
     }
 }

--- a/AdminWebsite/AdminWebsite/Mappers/HearingUpdateRequestMapper.cs
+++ b/AdminWebsite/AdminWebsite/Mappers/HearingUpdateRequestMapper.cs
@@ -27,7 +27,7 @@ namespace AdminWebsite.Mappers
                     }
                 },
                 QuestionnaireNotRequired = false,
-                AudioRecordingRequired = editHearingRequest.Participants.Any(x=>x.LinkedParticipants.Any(s=>(int) s.Type == (int) LinkedParticipantType.Interpreter)) || editHearingRequest.AudioRecordingRequired,
+                AudioRecordingRequired = editHearingRequest.AudioRecordingRequired
             };
             return updateHearingRequest;
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-10152


### Change description ###
Fixes an issue where the Audio Recording Required flag is changed from false to true when editing a booking with an interpreter for the Crime Crown Court or CACD case types. It should always be set to false for these case types.

The logic for whether this flag should be true or false lives in the frontend. However the backend duplicates this and overrides the value in the request if there are interpreters. This is not needed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
