### PR TITLE
VIH-10297 Fix for ejud accounts not populating in drop down search

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant.model.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant.model.ts
@@ -48,7 +48,7 @@ export class ParticipantModel {
         return judge
             ? {
                   ...judge,
-                  email: judge.contact_email,
+                  email: judge.contact_email ?? judge.email,
                   username: judge.email,
                   is_courtroom_account: judge.account_type === JudgeAccountType.Courtroom
               }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant.model.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant.model.ts
@@ -2,27 +2,27 @@ import { JudgeAccountType, JudgeResponse, PersonResponse } from 'src/app/service
 import { LinkedParticipantModel } from './linked-participant.model';
 
 export class ParticipantModel {
-    id?: string | undefined;
-    title?: string | undefined;
-    first_name?: string | undefined;
-    last_name?: string | undefined;
-    middle_names?: string | undefined;
-    display_name?: string | undefined;
-    username?: string | undefined;
-    email?: string | undefined;
-    case_role_name?: string | undefined;
-    hearing_role_name?: string | undefined;
-    hearing_role_code?: string | undefined;
-    phone?: string | undefined;
-    representee?: string | undefined;
-    company?: string | undefined;
+    id?: string;
+    title?: string;
+    first_name?: string;
+    last_name?: string;
+    middle_names?: string;
+    display_name?: string;
+    username?: string;
+    email?: string;
+    case_role_name?: string;
+    hearing_role_name?: string;
+    hearing_role_code?: string;
+    phone?: string;
+    representee?: string;
+    company?: string;
     is_judge?: boolean;
     is_exist_person?: boolean;
     interpreterFor?: string;
     linked_participants?: LinkedParticipantModel[];
-    interpretee_name?: string | undefined;
-    is_interpretee?: boolean | undefined;
-    user_role_name?: string | undefined;
+    interpretee_name?: string;
+    is_interpretee?: boolean;
+    user_role_name?: string;
     is_courtroom_account?: boolean;
     addedDuringHearing?: boolean;
     is_staff_member?: boolean;
@@ -56,6 +56,6 @@ export class ParticipantModel {
     }
 
     static IsEmailEjud(email: string): boolean {
-        return email && email.toLowerCase().includes('judiciary');
+        return email?.toLowerCase().includes('judiciary') ?? false;
     }
 }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.spec.ts
@@ -2,7 +2,7 @@ import { SearchService } from './search.service';
 import { TestBed } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
 import { of } from 'rxjs';
-import { BHClient, JudgeResponse, PersonResponse } from './clients/api-client';
+import { BHClient, JudgeAccountType, JudgeResponse, PersonResponse } from './clients/api-client';
 import { ParticipantModel } from '../common/model/participant.model';
 import { Constants } from '../common/constants';
 import { FeatureFlags, LaunchDarklyService } from './launch-darkly.service';
@@ -62,14 +62,26 @@ judge1.first_name = 'JudgeFirstName1';
 judge1.last_name = 'JudgeLastName1';
 judge1.display_name = 'JudgeDisplayName1';
 judge1.email = 'JudgeEmail1';
+judge1.contact_email = 'JudgeEmail1';
+judge1.account_type = JudgeAccountType.Courtroom;
 
 const judge2 = new JudgeResponse();
 judge2.first_name = 'JudgeFirstName2';
 judge2.last_name = 'JudgeLastName2';
 judge2.display_name = 'JudgeDisplayName2';
 judge2.email = 'JudgeEmail2';
+judge2.contact_email = 'JudgeEmail2';
+judge2.account_type = JudgeAccountType.Courtroom;
 
-const judgeList: JudgeResponse[] = [judge1, judge2];
+const ejudJudge = new JudgeResponse();
+ejudJudge.first_name = 'judgeEjud';
+ejudJudge.last_name = 'judgeEjud';
+ejudJudge.display_name = null;
+ejudJudge.email = 'judgeEjud';
+judge2.contact_email = null;
+ejudJudge.account_type = JudgeAccountType.Judiciary;
+
+const judgeList: JudgeResponse[] = [judge1, judge2, ejudJudge];
 
 const judgeParticipant1 = new ParticipantModel();
 judgeParticipant1.first_name = 'judgeParticipant1FirstName';
@@ -83,7 +95,13 @@ judgeParticipant2.last_name = 'judgeParticipant2LastName';
 judgeParticipant2.display_name = 'judgeParticipant2DisplayName';
 judgeParticipant2.email = 'judgeParticipant2Email';
 
-const judgeParticipantList: ParticipantModel[] = [judgeParticipant1, judgeParticipant2];
+const judgeParticipant3 = new ParticipantModel();
+judgeParticipant2.first_name = 'judgeParticipant2FirstName';
+judgeParticipant2.last_name = 'judgeParticipant2LastName';
+judgeParticipant2.display_name = null;
+judgeParticipant2.email = 'judgeEjud';
+
+const judgeParticipantList: ParticipantModel[] = [judgeParticipant1, judgeParticipant2, judgeParticipant3];
 
 const participant1 = new ParticipantModel();
 participant1.first_name = 'participant1FirstName';

--- a/AdminWebsite/AdminWebsite/Controllers/JudiciaryAccountsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/JudiciaryAccountsController.cs
@@ -97,7 +97,8 @@ namespace AdminWebsite.Controllers
 
                 await Task.WhenAll(courtRoomJudgesTask, eJudiciaryJudgesTask);
 
-                var eJudiciaryJudges = (await eJudiciaryJudgesTask).Where(p => !p.Username.Contains(_testSettings.TestUsernameStem)).ToList();
+                var eJudiciaryJudges = (await eJudiciaryJudgesTask)
+                    .Where(p => !p.Username.Contains(_testSettings.TestUsernameStem)).ToList();
                 var courtRoomJudges = (await courtRoomJudgesTask)
                     .Where(x => !eJudiciaryJudges.Select(e => e.Username).Contains(x.ContactEmail))
                     .Select(x => UserResponseMapper.MapFrom(x));


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10297

### Change description ###
Dropdown now correctly display the edjudicary accounts searched for in the assign-judge page. This is due to a mapping error, as the do not have contact emails, which is the value displayed in the drop down.