### PR TITLE
VIH-10326 Fix v2 toggle issues

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/booking-details.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/booking-details.service.ts
@@ -47,7 +47,7 @@ export class BookingDetailsService {
         const judges: Array<ParticipantDetailsModel> = [];
         const judicialMembers: Array<JudiciaryParticipantDetailsModel> = [];
 
-        const mappedJohs = hearingResponse.judiciary_participants.map(
+        const mappedJohs = hearingResponse.judiciary_participants?.map(
             j =>
                 new JudiciaryParticipantDetailsModel(
                     j.title,

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/clients/api-client.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/clients/api-client.ts
@@ -1868,6 +1868,114 @@ export class BHClient extends ApiClientBase {
     }
 
     /**
+     * Find judges and court rooms accounts list by email search term.
+     * @param body (optional) The email address search term.
+     * @return Success
+     */
+    postJudgesBySearchTerm(body: string | undefined): Observable<JudgeResponse[]> {
+        let url_ = this.baseUrl + '/api/judiciary/judges';
+        url_ = url_.replace(/[?&]$/, '');
+
+        const content_ = JSON.stringify(body);
+
+        let options_: any = {
+            body: content_,
+            observe: 'response',
+            responseType: 'blob',
+            headers: new HttpHeaders({
+                'Content-Type': 'application/json-patch+json',
+                Accept: 'application/json'
+            })
+        };
+
+        return _observableFrom(this.transformOptions(options_))
+            .pipe(
+                _observableMergeMap(transformedOptions_ => {
+                    return this.http.request('post', url_, transformedOptions_);
+                })
+            )
+            .pipe(
+                _observableMergeMap((response_: any) => {
+                    return this.processPostJudgesBySearchTerm(response_);
+                })
+            )
+            .pipe(
+                _observableCatch((response_: any) => {
+                    if (response_ instanceof HttpResponseBase) {
+                        try {
+                            return this.processPostJudgesBySearchTerm(response_ as any);
+                        } catch (e) {
+                            return _observableThrow(e) as any as Observable<JudgeResponse[]>;
+                        }
+                    } else return _observableThrow(response_) as any as Observable<JudgeResponse[]>;
+                })
+            );
+    }
+
+    protected processPostJudgesBySearchTerm(response: HttpResponseBase): Observable<JudgeResponse[]> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse
+                ? response.body
+                : (response as any).error instanceof Blob
+                ? (response as any).error
+                : undefined;
+
+        let _headers: any = {};
+        if (response.headers) {
+            for (let key of response.headers.keys()) {
+                _headers[key] = response.headers.get(key);
+            }
+        }
+        if (status === 500) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap((_responseText: string) => {
+                    let result500: any = null;
+                    let resultData500 = _responseText === '' ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                    result500 = UnexpectedErrorResponse.fromJS(resultData500);
+                    return throwException('Server Error', status, _responseText, _headers, result500);
+                })
+            );
+        } else if (status === 200) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap((_responseText: string) => {
+                    let result200: any = null;
+                    let resultData200 = _responseText === '' ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                    if (Array.isArray(resultData200)) {
+                        result200 = [] as any;
+                        for (let item of resultData200) result200!.push(JudgeResponse.fromJS(item));
+                    } else {
+                        result200 = <any>null;
+                    }
+                    return _observableOf(result200);
+                })
+            );
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap((_responseText: string) => {
+                    let result400: any = null;
+                    let resultData400 = _responseText === '' ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                    result400 = ProblemDetails.fromJS(resultData400);
+                    return throwException('Bad Request', status, _responseText, _headers, result400);
+                })
+            );
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap((_responseText: string) => {
+                    return throwException('Unauthorized', status, _responseText, _headers);
+                })
+            );
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap((_responseText: string) => {
+                    return throwException('An unexpected server error occurred.', status, _responseText, _headers);
+                })
+            );
+        }
+        return _observableOf(null as any);
+    }
+
+    /**
      * Find judiciary person list by email search term.
      * @param body (optional) The email address search term.
      * @return Success

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.spec.ts
@@ -136,15 +136,15 @@ describe('SearchService', () => {
     beforeEach(() => {
         clientApiSpy = jasmine.createSpyObj<BHClient>('BHClient', [
             'postPersonBySearchTerm',
-            'searchForJudiciaryPerson',
             'postJudiciaryPersonBySearchTerm',
+            'postJudgesBySearchTerm',
             'getStaffMembersBySearchTerm'
         ]);
 
         clientApiSpy.postPersonBySearchTerm.and.returnValue(of(personList));
         clientApiSpy.getStaffMembersBySearchTerm.and.returnValue(of(staffMemberList));
-        clientApiSpy.searchForJudiciaryPerson.and.returnValue(of(judiciaryPersonList));
-        clientApiSpy.postJudiciaryPersonBySearchTerm.and.returnValue(of(judgeList));
+        clientApiSpy.postJudiciaryPersonBySearchTerm.and.returnValue(of(judiciaryPersonList));
+        clientApiSpy.postJudgesBySearchTerm.and.returnValue(of(judgeList));
 
         launchDarklyServiceSpy.getFlag.withArgs(FeatureFlags.eJudFeature).and.returnValue(of(true));
 
@@ -166,8 +166,8 @@ describe('SearchService', () => {
         beforeEach(() => {
             clientApiSpy = jasmine.createSpyObj<BHClient>('BHClient', [
                 'postPersonBySearchTerm',
-                'searchForJudiciaryPerson',
                 'postJudiciaryPersonBySearchTerm',
+                'postJudgesBySearchTerm',
                 'getStaffMembersBySearchTerm'
             ]);
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.ts
@@ -94,7 +94,7 @@ export class SearchService {
     }
 
     searchJudiciaryEntries(term): Observable<Array<PersonResponse>> {
-        return this.bhClient.searchForJudiciaryPerson(term);
+        return this.bhClient.postJudiciaryPersonBySearchTerm(term);
     }
 
     searchStaffMemberAccounts(term): Observable<Array<PersonResponse>> {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/search.service.ts
@@ -102,6 +102,6 @@ export class SearchService {
     }
 
     searchJudgeAccounts(term): Observable<Array<JudgeResponse>> {
-        return this.bhClient.postJudiciaryPersonBySearchTerm(term);
+        return this.bhClient.postJudgesBySearchTerm(term);
     }
 }

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
@@ -217,9 +217,11 @@ export class VideoHearingsService {
         hearing.scheduled_date_time = new Date(booking.scheduled_date_time);
         hearing.scheduled_duration = booking.scheduled_duration;
         hearing.participants = this.mapParticipantModelToEditParticipantRequest(booking.participants);
-        hearing.judiciary_participants = this.mapJudicialMemberDtoToJudiciaryParticipantRequest(booking.judiciaryParticipants);
         hearing.audio_recording_required = booking.audio_recording_required;
         hearing.endpoints = this.mapEndpointModelToEditEndpointRequest(booking.endpoints);
+        if (booking.judiciaryParticipants?.length > 0) {
+            hearing.judiciary_participants = this.mapJudicialMemberDtoToJudiciaryParticipantRequest(booking.judiciaryParticipants);
+        }
         return hearing;
     }
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
@@ -326,7 +326,7 @@ export class VideoHearingsService {
         hearing.status = response.status;
         hearing.audio_recording_required = response.audio_recording_required;
         hearing.endpoints = this.mapEndpointResponseToEndpointModel(response.endpoints, response.participants);
-        hearing.judiciaryParticipants = response.judiciary_participants.map(judiciaryParticipant =>
+        hearing.judiciaryParticipants = response.judiciary_participants?.map(judiciaryParticipant =>
             JudicialMemberDto.fromJudiciaryParticipantResponse(judiciaryParticipant)
         );
         hearing.isConfirmed = Boolean(response.confirmed_date);

--- a/AdminWebsite/AdminWebsite/Mappers/JudgeResponseMapper.cs
+++ b/AdminWebsite/AdminWebsite/Mappers/JudgeResponseMapper.cs
@@ -18,5 +18,17 @@ namespace AdminWebsite.Mappers
             };
 
         }
+
+        public static JudgeResponse MapTo(PersonResponse personResponse)
+        {
+            return new JudgeResponse
+            {
+                FirstName = personResponse.FirstName,
+                LastName = personResponse.LastName,
+                Email = personResponse.Username,
+                AccountType = JudgeAccountType.Judiciary,
+                ContactEmail = personResponse.ContactEmail
+            };
+        }
     }
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10326


### Change description ###
Fixes the admin web issues when the Use Bookings API V2 feature flag is toggled off.
- Error booking a hearing
- Judge name not auto-populating after selecting them on the booking form

The issue was introduced as part of adding the Judicial Office Holders component.

The PostJudgesBySearchTerm endpoint had been removed and the search.service was changed to call a different endpoint which returns a PersonResponse instead of a JudgeResponse. This change was not needed as the search service is not referenced by the Judicial Office Holders component, so I have reverted the service changes and reinstated the original API endpoint and its tests.