### PR TITLE
VIH-10363 Fix judge name disappearing on booking list when V2 switched on

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
@@ -77,6 +77,10 @@ export const Constants = {
         Observer: 'Observer',
         Interpreter: 'Interpreter'
     },
+    UserRoles: {
+        Judge: 'Judge',
+        StaffMember: 'Staff Member'
+    },
     ManageJusticeUsers: {
         EmptySearchResults:
             'No users matching this search criteria were found. Please check the search and try again. Or, add the team member.',

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.spec.ts
@@ -116,7 +116,7 @@ describe('BookingsPersistService', () => {
             expect(updatedHearing.JudgeName).toBe(judge.display_name);
         });
 
-        it('should update judiciary participant judge name for selected hearing', () => {
+        it('should update judge name for selected hearing with judiciary participant judge', () => {
             service.bookingList = [MockGroupedBookings([MockBookedHearing(), MockBookedHearing()])];
 
             service.selectedGroupIndex = 0;
@@ -142,6 +142,34 @@ describe('BookingsPersistService', () => {
 
             const updatedHearing = service.bookingList[0].BookingsDetails[0];
             expect(updatedHearing.JudgeName).toBe(judge.displayName);
+        });
+
+        it('should update judge name for selected hearing with judiciary participants but no judge', () => {
+            service.bookingList = [MockGroupedBookings([MockBookedHearing(), MockBookedHearing()])];
+
+            service.selectedGroupIndex = 0;
+            service.selectedItemIndex = 0;
+
+            const hearing = new HearingModel();
+            hearing.court_id = 1;
+            hearing.court_room = 'court room';
+            hearing.court_name = 'court';
+            const judiciaryParticipants: JudicialMemberDto[] = [];
+            const participant = new JudicialMemberDto('Panel', 'Member', 'Panel Member', 'email', 'telephone', 'personalCode');
+            participant.displayName = 'Panel Member';
+            participant.roleCode = 'PanelMember';
+            judiciaryParticipants.push(participant);
+            hearing.judiciaryParticipants = judiciaryParticipants;
+
+            const updatedCase = new CaseModel();
+            updatedCase.name = 'updated case';
+            hearing.cases = [updatedCase];
+
+            hearing.hearing_id = service.bookingList[0].BookingsDetails[0].HearingId;
+            service.updateBooking(hearing);
+
+            const updatedHearing = service.bookingList[0].BookingsDetails[0];
+            expect(updatedHearing.JudgeName).toBe('');
         });
     });
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.spec.ts
@@ -3,6 +3,8 @@ import { HearingModel } from 'src/app/common/model/hearing.model';
 import { BookingPersistService } from './bookings-persist.service';
 import { v4 as uuid } from 'uuid';
 import { CaseModel } from '../common/model/case.model';
+import { ParticipantModel } from '../common/model/participant.model';
+import { JudicialMemberDto } from '../booking/judicial-office-holders/models/add-judicial-member.model';
 
 function MockGroupedBookings(hearings: BookingsDetailsModel[]): BookingsListModel {
     const model = new BookingsListModel(new Date());
@@ -86,6 +88,60 @@ describe('BookingsPersistService', () => {
 
             const updatedHearing = service.bookingList[0].BookingsDetails[0];
             expect(updatedHearing.HearingCaseName).toBe(updatedCase.name);
+        });
+
+        it('should update judge name for selected hearing', () => {
+            service.bookingList = [MockGroupedBookings([MockBookedHearing(), MockBookedHearing()])];
+
+            service.selectedGroupIndex = 0;
+            service.selectedItemIndex = 0;
+
+            const hearing = new HearingModel();
+            hearing.court_id = 1;
+            hearing.court_room = 'court room';
+            hearing.court_name = 'court';
+            const participants: ParticipantModel[] = [];
+            const judge = new ParticipantModel({ is_judge: true, display_name: 'Judge Test' });
+            participants.push(judge);
+            hearing.participants = participants;
+
+            const updatedCase = new CaseModel();
+            updatedCase.name = 'updated case';
+            hearing.cases = [updatedCase];
+
+            hearing.hearing_id = service.bookingList[0].BookingsDetails[0].HearingId;
+            service.updateBooking(hearing);
+
+            const updatedHearing = service.bookingList[0].BookingsDetails[0];
+            expect(updatedHearing.JudgeName).toBe(judge.display_name);
+        });
+
+        it('should update judiciary participant judge name for selected hearing', () => {
+            service.bookingList = [MockGroupedBookings([MockBookedHearing(), MockBookedHearing()])];
+
+            service.selectedGroupIndex = 0;
+            service.selectedItemIndex = 0;
+
+            const hearing = new HearingModel();
+            hearing.court_id = 1;
+            hearing.court_room = 'court room';
+            hearing.court_name = 'court';
+            const judiciaryParticipants: JudicialMemberDto[] = [];
+            const judge = new JudicialMemberDto('Judge', 'One', 'Judge One', 'email', 'telephone', 'personalCode');
+            judge.displayName = 'Judge Test';
+            judge.roleCode = 'Judge';
+            judiciaryParticipants.push(judge);
+            hearing.judiciaryParticipants = judiciaryParticipants;
+
+            const updatedCase = new CaseModel();
+            updatedCase.name = 'updated case';
+            hearing.cases = [updatedCase];
+
+            hearing.hearing_id = service.bookingList[0].BookingsDetails[0].HearingId;
+            service.updateBooking(hearing);
+
+            const updatedHearing = service.bookingList[0].BookingsDetails[0];
+            expect(updatedHearing.JudgeName).toBe(judge.displayName);
         });
     });
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/bookings-persist.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BookingsListModel, BookingsDetailsModel } from '../common/model/bookings-list.model';
 import { HearingModel } from '../common/model/hearing.model';
-import { ParticipantModel } from '../common/model/participant.model';
 
 @Injectable({ providedIn: 'root' })
 export class BookingPersistService {
@@ -59,7 +58,7 @@ export class BookingPersistService {
                 if (this.isValidDate(hearing.updated_date)) {
                     hearingUpdate.LastEditDate = new Date(hearing.updated_date);
                 }
-                hearingUpdate.JudgeName = this.getJudgeName(hearing.participants);
+                hearingUpdate.JudgeName = this.getJudgeName(hearing);
                 return hearingUpdate;
             }
         }
@@ -73,8 +72,13 @@ export class BookingPersistService {
         return false;
     }
 
-    getJudgeName(participants: ParticipantModel[]) {
-        const judge = participants.find(x => x.case_role_name === 'Judge');
+    getJudgeName(hearing: HearingModel) {
+        if (hearing.judiciaryParticipants && hearing.judiciaryParticipants.length > 0) {
+            const judiciaryJudge = hearing.judiciaryParticipants.find(x => x.roleCode === 'Judge');
+            return judiciaryJudge ? judiciaryJudge.displayName : '';
+        }
+
+        const judge = hearing.participants.find(x => x.is_judge);
         return judge ? judge.display_name : '';
     }
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.spec.ts
@@ -246,7 +246,22 @@ describe('Video hearing service', () => {
         participant.telephone_number = '123123123';
         participant.case_role_name = 'Respondent';
         participant.hearing_role_name = 'Litigant in person';
+        participant.user_role_name = 'Individual';
         participants.push(participant);
+
+        const judgeParticipant = new ParticipantResponse();
+        judgeParticipant.title = 'Mr';
+        judgeParticipant.first_name = 'Judge';
+        judgeParticipant.middle_names = 'MiddleNames';
+        judgeParticipant.last_name = 'Test';
+        judgeParticipant.username = 'judge@hmcts.net';
+        judgeParticipant.display_name = 'Judge Test';
+        judgeParticipant.contact_email = 'judge@hmcts.net';
+        judgeParticipant.telephone_number = '123123123';
+        judgeParticipant.case_role_name = null;
+        judgeParticipant.hearing_role_name = null;
+        judgeParticipant.user_role_name = 'Judge';
+        participants.push(judgeParticipant);
 
         const model = service.mapParticipantResponseToParticipantModel(participants);
 
@@ -260,6 +275,19 @@ describe('Video hearing service', () => {
         expect(model[0].phone).toEqual(participant.telephone_number);
         expect(model[0].case_role_name).toEqual(participant.case_role_name);
         expect(model[0].hearing_role_name).toEqual(participant.hearing_role_name);
+        expect(model[0].is_judge).toBeFalse();
+
+        expect(model[1].title).toEqual(judgeParticipant.title);
+        expect(model[1].first_name).toEqual(judgeParticipant.first_name);
+        expect(model[1].middle_names).toEqual(judgeParticipant.middle_names);
+        expect(model[1].last_name).toEqual(judgeParticipant.last_name);
+        expect(model[1].username).toEqual(judgeParticipant.username);
+        expect(model[1].display_name).toEqual(judgeParticipant.display_name);
+        expect(model[1].email).toEqual(judgeParticipant.contact_email);
+        expect(model[1].phone).toEqual(judgeParticipant.telephone_number);
+        expect(model[1].case_role_name).toEqual(judgeParticipant.case_role_name);
+        expect(model[1].hearing_role_name).toEqual(judgeParticipant.hearing_role_name);
+        expect(model[1].is_judge).toBeTrue();
     });
 
     it('should map ParticipantModel toParticipantResponse', () => {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
@@ -433,11 +433,8 @@ export class VideoHearingsService {
                 participant.hearing_role_code = p.hearing_role_code;
                 participant.representee = p.representee;
                 participant.company = p.organisation;
-                participant.is_judge =
-                    p.case_role_name === Constants.HearingRoles.Judge || p.hearing_role_code === Constants.HearingRoleCodes.Judge;
-                participant.is_staff_member =
-                    p.case_role_name === Constants.HearingRoles.StaffMember ||
-                    p.hearing_role_code === Constants.HearingRoleCodes.StaffMember;
+                participant.is_judge = p.user_role_name === Constants.UserRoles.Judge;
+                participant.is_staff_member = p.user_role_name === Constants.UserRoles.StaffMember;
                 participant.linked_participants = this.mapLinkedParticipantResponseToLinkedParticipantModel(p.linked_participants);
                 participant.user_role_name = p.user_role_name;
                 participants.push(participant);

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/video-hearings.service.ts
@@ -27,8 +27,7 @@ import {
     BookingStatus,
     AllocatedCsoResponse,
     HearingRoleResponse,
-    JudiciaryParticipantRequest,
-    JudiciaryParticipantResponse
+    JudiciaryParticipantRequest
 } from './clients/api-client';
 import { HearingModel } from '../common/model/hearing.model';
 import { CaseModel } from '../common/model/case.model';


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10363


### Change description ###
2 changes needed:

1. Get the judge name from judiciary participants if the judge is booked as a judiciary participant
2. Update `is_judge` and `is_staff_member` to look at the user role name. The case and hearing role are null when V2 is switched on so instead read from user role name, which is populated for both V1 and V2
