### PR TITLE
VIH-10362 Fix issue with judge display name not auto populating for ejud and V1 API

### DIFF
--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/JudiciaryAccountsControllerTest.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/JudiciaryAccountsControllerTest.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Net;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using AdminWebsite.Mappers;
 using BookingsApi.Client;
 using BookingsApi.Contract.V1.Requests;
 using BookingsApi.Contract.V1.Responses;
@@ -385,8 +386,24 @@ namespace AdminWebsite.UnitTests.Controllers
             okRequestResult.StatusCode.Should().NotBeNull();
             var personRespList = (List<JudgeResponse>)okRequestResult.Value;
 
-            var expectedJudiciaryCount = withJudiciary ? _judiciaryResponse.Count : 0;
-            var expectedCourtRoomCount = withCourtroom ? _courtRoomResponse.Count : 0;
+            var expectedResponse = new List<JudgeResponse>();
+            var expectedJudiciaryResponses = new List<JudgeResponse>();
+            var expectedCourtRoomResponses = new List<JudgeResponse>();
+
+            if (withJudiciary)
+            {
+                expectedJudiciaryResponses = _judiciaryResponse.Select(JudgeResponseMapper.MapTo).ToList();
+                expectedResponse.AddRange(expectedJudiciaryResponses);
+            }
+
+            if (withCourtroom)
+            {
+                expectedCourtRoomResponses = _courtRoomResponse.ToList();
+                expectedResponse.AddRange(_courtRoomResponse);
+            }
+
+            var expectedJudiciaryCount = withJudiciary ? expectedJudiciaryResponses.Count : 0;
+            var expectedCourtRoomCount = withCourtroom ? expectedCourtRoomResponses.Count : 0;
 
             var expectedTotal = expectedJudiciaryCount + expectedCourtRoomCount;
 
@@ -397,6 +414,8 @@ namespace AdminWebsite.UnitTests.Controllers
                 Assert.That(personRespList, Is.Not.EqualTo(_courtRoomResponse));
                 Assert.That(personRespList, Is.EqualTo(_courtRoomResponse.OrderBy(x => x.Email)));
             }
+
+            personRespList.Should().BeEquivalentTo(expectedResponse);
         }
 
         [Test]

--- a/AdminWebsite/AdminWebsite.UnitTests/Mappers/JudgeResponseMapperTest.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Mappers/JudgeResponseMapperTest.cs
@@ -1,4 +1,5 @@
-﻿using AdminWebsite.Contracts.Responses;
+﻿using AdminWebsite.Contracts.Enums;
+using AdminWebsite.Contracts.Responses;
 using AdminWebsite.Mappers;
 using BookingsApi.Contract.V1.Responses;
 using FluentAssertions;
@@ -25,6 +26,30 @@ namespace AdminWebsite.UnitTests.Mappers
             judgeResponse.LastName.Should().Be(personResponse.LastName);
             judgeResponse.Email.Should().Be(personResponse.Email);
             judgeResponse.ContactEmail.Should().Be(personResponse.ContactEmail);
+        }
+
+        [Test]
+        public void Should_map_judiciary_person_response_to_judge_response()
+        {
+            var judiciaryPersonResponse = new JudiciaryPersonResponse
+            {
+                Title = "Mr",
+                FirstName = "FirstName",
+                LastName = "LastName",
+                FullName = "FirstName LastName",
+                Email = "email@email.com",
+                WorkPhone = "123",
+                PersonalCode = "PersonalCode"
+            };
+
+            var judgeResponse = JudgeResponseMapper.MapTo(judiciaryPersonResponse);
+
+            judgeResponse.FirstName.Should().Be(judiciaryPersonResponse.FirstName);
+            judgeResponse.LastName.Should().Be(judiciaryPersonResponse.LastName);
+            judgeResponse.DisplayName.Should().Be(judiciaryPersonResponse.FullName);
+            judgeResponse.Email.Should().Be(judiciaryPersonResponse.Email);
+            judgeResponse.ContactEmail.Should().Be(judiciaryPersonResponse.Email);
+            judgeResponse.AccountType.Should().Be(JudgeAccountType.Judiciary);
         }
     }
 }

--- a/AdminWebsite/AdminWebsite/Controllers/JudiciaryAccountsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/JudiciaryAccountsController.cs
@@ -46,6 +46,8 @@ namespace AdminWebsite.Controllers
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
         public async Task<ActionResult<IList<JudgeResponse>>> PostJudgesBySearchTermAsync([FromBody] string term)
         {
+            // This is the v1 ejud search for judges
+            
             try
             {
                 term = _encoder.Encode(term);
@@ -86,20 +88,24 @@ namespace AdminWebsite.Controllers
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
         public async Task<ActionResult<IList<PersonResponse>>> PostJudiciaryPersonBySearchTermAsync([FromBody] string term)
         {
+            // This is the v1 ejud search for panel members and wingers
+            
             try
             {
                 term = _encoder.Encode(term);
                 var searchTerm = new SearchTermRequest(term);
                 var courtRoomJudgesTask = _userAccountService.SearchEjudiciaryJudgesByEmailUserResponse(searchTerm.Term);
                 var eJudiciaryJudgesTask = GetEjudiciaryJudgesBySearchTermAsync(searchTerm);
-
+        
                 await Task.WhenAll(courtRoomJudgesTask, eJudiciaryJudgesTask);
-
+        
                 var eJudiciaryJudges = (await eJudiciaryJudgesTask)
-                    .Where(p => !p.Username.Contains(_testSettings.TestUsernameStem)).ToList();
+                    .Where(p => !p.Email.Contains(_testSettings.TestUsernameStem))
+                    .Select(p => p.MapToPersonResponse())
+                    .ToList();
                 var courtRoomJudges = (await courtRoomJudgesTask)
                     .Where(x => !eJudiciaryJudges.Select(e => e.Username).Contains(x.ContactEmail))
-                    .Select(x => UserResponseMapper.MapFrom(x));
+                    .Select(UserResponseMapper.MapFrom);
                 
                 var allJudges = courtRoomJudges.Concat(eJudiciaryJudges)
                     .OrderBy(x => x.ContactEmail).Take(20).ToList();
@@ -126,6 +132,8 @@ namespace AdminWebsite.Controllers
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
         public async Task<ActionResult<List<JudiciaryPerson>>> SearchForJudiciaryPersonAsync([FromBody] string term)
         {
+            // This is the v2 search for judicial office holders
+            
             try
             {
                 term = _encoder.Encode(term);
@@ -146,11 +154,10 @@ namespace AdminWebsite.Controllers
                 throw;
             }
         }
-        
-        private async Task<List<PersonResponse>> GetEjudiciaryJudgesBySearchTermAsync(SearchTermRequest term)
+
+        private async Task<List<JudiciaryPersonResponse>> GetEjudiciaryJudgesBySearchTermAsync(SearchTermRequest term)
         {
-            var judiciaryPersonResponses = (await _bookingsApiClient.PostJudiciaryPersonBySearchTermAsync(term)).ToList();
-            return judiciaryPersonResponses.Select(x => x.MapToPersonResponse()).ToList();
+            return (await _bookingsApiClient.PostJudiciaryPersonBySearchTermAsync(term)).ToList();
         }
     }
 }

--- a/AdminWebsite/AdminWebsite/Mappers/JudgeResponseMapper.cs
+++ b/AdminWebsite/AdminWebsite/Mappers/JudgeResponseMapper.cs
@@ -30,5 +30,18 @@ namespace AdminWebsite.Mappers
                 ContactEmail = personResponse.ContactEmail
             };
         }
+
+        public static JudgeResponse MapTo(JudiciaryPersonResponse personResponse)
+        {
+            return new JudgeResponse
+            {
+                FirstName = personResponse.FirstName,
+                LastName = personResponse.LastName,
+                DisplayName = personResponse.FullName,
+                Email = personResponse.Email,
+                ContactEmail = personResponse.Email,
+                AccountType = JudgeAccountType.Judiciary
+            };
+        }
     }
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10362


### Change description ###
Mapping judiciary persons to a person response removes the display name property, so don't do this for the V1 ejud judges search - map to a judge response instead