### PR TITLE
VIH-10361 Fix for unable to update judge last minute

### DIFF
--- a/AdminWebsite/AdminWebsite.IntegrationTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.IntegrationTests/packages.lock.json
@@ -102,8 +102,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.49.15",
-        "contentHash": "ye+s7y4jeNSgVd7sgbRee0dnx4HZIegmBxYlWHENPNv5u8zSH15dENPmLX8BODkUKOLpwHiIxQyRMh8KKzlcFQ==",
+        "resolved": "1.50.4-pr-0788-0003",
+        "contentHash": "A/VDJHlJM82MzrM0RdaZEvPwyFUQGe5fxq86dBKVCh4Iy0gfJhOV4myVYVdtFyPzVeRO5ObxyGuGM7Tmam4gJg==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2101,7 +2101,7 @@
         "type": "Project",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "[6.0.3, )",
-          "BookingsApi.Client": "[1.49.15, )",
+          "BookingsApi.Client": "[1.50.4-pr-0788-0003, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite.IntegrationTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.IntegrationTests/packages.lock.json
@@ -102,8 +102,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.50.4-pr-0788-0003",
-        "contentHash": "A/VDJHlJM82MzrM0RdaZEvPwyFUQGe5fxq86dBKVCh4Iy0gfJhOV4myVYVdtFyPzVeRO5ObxyGuGM7Tmam4gJg==",
+        "resolved": "1.50.6",
+        "contentHash": "Ns9rPj4+jc2XpR3XSNHUMk+ZVbbmjhcXaBt1eHeQTtnBBkkSMTfbwK5kUJ4xrXhiwEjg32h6Njq5b3Y9L8Kd2w==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2101,7 +2101,7 @@
         "type": "Project",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "[6.0.3, )",
-          "BookingsApi.Client": "[1.50.4-pr-0788-0003, )",
+          "BookingsApi.Client": "[1.50.6, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditHearingTests.cs
@@ -623,6 +623,13 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
             }).ToList();
             var panelMemberToRemove = _addNewParticipantRequest.JudiciaryParticipants.Find(x => x.Role == "PanelMember");
             _addNewParticipantRequest.JudiciaryParticipants.Remove(panelMemberToRemove);
+            var panelMemberToAdd = new JudiciaryParticipantRequest
+            {
+                DisplayName = "NewPanelMemberDisplayName",
+                PersonalCode = "NewPanelMemberPersonalCode",
+                Role = "PanelMember"
+            };
+            _addNewParticipantRequest.JudiciaryParticipants.Add(panelMemberToAdd);
 
             var result = await _controller.EditHearing(_validId, _addNewParticipantRequest);
             var hearing = (AdminWebsite.Contracts.Responses.HearingDetailsResponse)((OkObjectResult)result.Result).Value;
@@ -634,10 +641,21 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
 
             var existingJudge = _addNewParticipantRequest.JudiciaryParticipants.Find(x => x.Role == "Judge");
             
-            _bookingsApiClient.Verify(x => x.RemoveJudiciaryParticipantFromHearingAsync(hearing.Id, panelMemberToRemove.PersonalCode),
+            _bookingsApiClient.Verify(x => x.RemoveJudiciaryParticipantFromHearingAsync(
+                    hearing.Id, 
+                    panelMemberToRemove.PersonalCode),
                 Times.Once);
             
-            _bookingsApiClient.Verify(x => x.UpdateJudiciaryParticipantAsync(hearing.Id, existingJudge.PersonalCode, It.IsAny<UpdateJudiciaryParticipantRequest>()),
+            _bookingsApiClient.Verify(x => x.UpdateJudiciaryParticipantAsync(
+                    hearing.Id, 
+                    existingJudge.PersonalCode, 
+                    It.IsAny<UpdateJudiciaryParticipantRequest>()),
+                Times.Once);
+            
+            _bookingsApiClient.Verify(x => x.AddJudiciaryParticipantsToHearingAsync(
+                    hearing.Id, 
+                    It.Is<List<BookingsApi.Contract.V1.Requests.JudiciaryParticipantRequest>>(r => 
+                            r.Any(y => y.PersonalCode == panelMemberToAdd.PersonalCode))),
                 Times.Once);
         }
         

--- a/AdminWebsite/AdminWebsite.UnitTests/Services/HearingServiceTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Services/HearingServiceTests.cs
@@ -293,13 +293,9 @@ namespace AdminWebsite.UnitTests.Services
                 .With(x => x.Id = Guid.NewGuid())
                 .With(x => x.UserRoleName = "Staff Member")
                 .Build();
-            var telephoneParticipant = Builder<TelephoneParticipantResponse>.CreateNew()
-                .With(x => x.Id = Guid.NewGuid())
-                .Build();
 
             return Builder<HearingDetailsResponse>.CreateNew()
                 .With(h => h.Participants = new List<ParticipantResponse> { rep, ind, joh, judge, staffMember })
-                .With(h => h.TelephoneParticipants = new List<TelephoneParticipantResponse> { telephoneParticipant })
                 .With(x => x.Cases = cases)
                 .With(x => x.Id = Guid.NewGuid())
                 .Build();

--- a/AdminWebsite/AdminWebsite.UnitTests/Validators/EditHearingRequestValidatorTest.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Validators/EditHearingRequestValidatorTest.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using AdminWebsite.Contracts.Requests;
 
 namespace AdminWebsite.UnitTests.Validators
 {
@@ -42,6 +43,17 @@ namespace AdminWebsite.UnitTests.Validators
         {
             var testRequest = new EditHearingRequest {
                 Participants = new List<EditParticipantRequest> { new EditParticipantRequest() },
+                Case = new EditCaseRequest(),
+            };
+            var result = _validator.Validate(testRequest);
+            Assert.That(!result.Errors.Any(o => o.PropertyName == "Participants"));
+        }
+        
+        [Test]
+        public void Should_validate_participants_as_valid_when_judiciary_participants_are_provided()
+        {
+            var testRequest = new EditHearingRequest {
+                JudiciaryParticipants = new List<JudiciaryParticipantRequest> { new() },
                 Case = new EditCaseRequest(),
             };
             var result = _validator.Validate(testRequest);

--- a/AdminWebsite/AdminWebsite.UnitTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.UnitTests/packages.lock.json
@@ -107,8 +107,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.50.4-pr-0788-0003",
-        "contentHash": "A/VDJHlJM82MzrM0RdaZEvPwyFUQGe5fxq86dBKVCh4Iy0gfJhOV4myVYVdtFyPzVeRO5ObxyGuGM7Tmam4gJg==",
+        "resolved": "1.50.6",
+        "contentHash": "Ns9rPj4+jc2XpR3XSNHUMk+ZVbbmjhcXaBt1eHeQTtnBBkkSMTfbwK5kUJ4xrXhiwEjg32h6Njq5b3Y9L8Kd2w==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1979,7 +1979,7 @@
         "type": "Project",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "[6.0.3, )",
-          "BookingsApi.Client": "[1.50.4-pr-0788-0003, )",
+          "BookingsApi.Client": "[1.50.6, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite.UnitTests/packages.lock.json
+++ b/AdminWebsite/AdminWebsite.UnitTests/packages.lock.json
@@ -107,8 +107,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.49.15",
-        "contentHash": "ye+s7y4jeNSgVd7sgbRee0dnx4HZIegmBxYlWHENPNv5u8zSH15dENPmLX8BODkUKOLpwHiIxQyRMh8KKzlcFQ==",
+        "resolved": "1.50.4-pr-0788-0003",
+        "contentHash": "A/VDJHlJM82MzrM0RdaZEvPwyFUQGe5fxq86dBKVCh4Iy0gfJhOV4myVYVdtFyPzVeRO5ObxyGuGM7Tmam4gJg==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1979,7 +1979,7 @@
         "type": "Project",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "[6.0.3, )",
-          "BookingsApi.Client": "[1.49.15, )",
+          "BookingsApi.Client": "[1.50.4-pr-0788-0003, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "LaunchDarkly.ServerSdk": "[7.0.3, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",

--- a/AdminWebsite/AdminWebsite/AdminWebsite.csproj
+++ b/AdminWebsite/AdminWebsite/AdminWebsite.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
-    <PackageReference Include="BookingsApi.Client" Version="1.50.4-pr-0788-0003" />
+    <PackageReference Include="BookingsApi.Client" Version="1.50.6" />
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="7.0.3" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.51.0" />

--- a/AdminWebsite/AdminWebsite/AdminWebsite.csproj
+++ b/AdminWebsite/AdminWebsite/AdminWebsite.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
-    <PackageReference Include="BookingsApi.Client" Version="1.49.15" />
+    <PackageReference Include="BookingsApi.Client" Version="1.50.4-pr-0788-0003" />
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="7.0.3" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.51.0" />

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -470,6 +470,14 @@ namespace AdminWebsite.Controllers
 
             foreach (var joh in existingJohs)
             {
+                // Only update the joh if their details have changed
+                var originalJoh = originalHearing.JudiciaryParticipants.Find(x => x.PersonalCode == joh.PersonalCode);
+                if (joh.DisplayName == originalJoh.DisplayName &&
+                    joh.Role == originalJoh.RoleCode)
+                {
+                    continue;
+                }
+                
                 var roleCode = Enum.Parse<JudiciaryParticipantHearingRoleCode>(joh.Role);
                 await _bookingsApiClient.UpdateJudiciaryParticipantAsync(hearingId, joh.PersonalCode,
                     new UpdateJudiciaryParticipantRequest()

--- a/AdminWebsite/AdminWebsite/Mappers/HearingDetailsResponseMapper.cs
+++ b/AdminWebsite/AdminWebsite/Mappers/HearingDetailsResponseMapper.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using AdminWebsite.Contracts.Responses;
 using V1 = BookingsApi.Contract.V1.Responses;
@@ -23,9 +24,7 @@ public static class HearingDetailsResponseMapper
                 Number = e.Number
             }).ToList(),
             Participants = hearingDetails.Participants?.Map(),
-            TelephoneParticipants = hearingDetails.TelephoneParticipants?
-                .Select(t => t.Map())
-                .ToList(),
+            TelephoneParticipants = new List<TelephoneParticipantResponse>(),
             HearingRoomName = hearingDetails.HearingRoomName,
             OtherInformation = hearingDetails.OtherInformation,
             CreatedDate = hearingDetails.CreatedDate,

--- a/AdminWebsite/AdminWebsite/Validators/EditHearingRequestValidator.cs
+++ b/AdminWebsite/AdminWebsite/Validators/EditHearingRequestValidator.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using AdminWebsite.Models;
+﻿using AdminWebsite.Models;
 using FluentValidation;
 
 namespace AdminWebsite.Validators
@@ -19,6 +18,7 @@ namespace AdminWebsite.Validators
 
             RuleFor(x => x.Participants)
                 .Must(x => x != null && x.Count > 0)
+                .When(x => x.JudiciaryParticipants == null || x.JudiciaryParticipants.Count == 0)
                 .WithMessage(PARTICIPANT_MSG);
 
             RuleForEach(x => x.Participants).NotNull().SetValidator(new EditParticipantRequestValidation());

--- a/AdminWebsite/AdminWebsite/packages.lock.json
+++ b/AdminWebsite/AdminWebsite/packages.lock.json
@@ -14,9 +14,9 @@
       },
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.50.4-pr-0788-0003, )",
-        "resolved": "1.50.4-pr-0788-0003",
-        "contentHash": "A/VDJHlJM82MzrM0RdaZEvPwyFUQGe5fxq86dBKVCh4Iy0gfJhOV4myVYVdtFyPzVeRO5ObxyGuGM7Tmam4gJg==",
+        "requested": "[1.50.6, )",
+        "resolved": "1.50.6",
+        "contentHash": "Ns9rPj4+jc2XpR3XSNHUMk+ZVbbmjhcXaBt1eHeQTtnBBkkSMTfbwK5kUJ4xrXhiwEjg32h6Njq5b3Y9L8Kd2w==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }

--- a/AdminWebsite/AdminWebsite/packages.lock.json
+++ b/AdminWebsite/AdminWebsite/packages.lock.json
@@ -14,9 +14,9 @@
       },
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.49.15, )",
-        "resolved": "1.49.15",
-        "contentHash": "ye+s7y4jeNSgVd7sgbRee0dnx4HZIegmBxYlWHENPNv5u8zSH15dENPmLX8BODkUKOLpwHiIxQyRMh8KKzlcFQ==",
+        "requested": "[1.50.4-pr-0788-0003, )",
+        "resolved": "1.50.4-pr-0788-0003",
+        "contentHash": "A/VDJHlJM82MzrM0RdaZEvPwyFUQGe5fxq86dBKVCh4Iy0gfJhOV4myVYVdtFyPzVeRO5ObxyGuGM7Tmam4gJg==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }

--- a/charts/vh-admin-web/values.dev.template.yaml
+++ b/charts/vh-admin-web/values.dev.template.yaml
@@ -9,3 +9,4 @@ java:
     AZUREAD__REDIRECTURI: https://${SERVICE_FQDN}/home
     DOM1__POSTLOGOUTREDIRECTURI: https://${SERVICE_FQDN}/logout
     DOM1__REDIRECTURI: https://${SERVICE_FQDN}/home
+    VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-788.dev.platform.hmcts.net/

--- a/charts/vh-admin-web/values.dev.template.yaml
+++ b/charts/vh-admin-web/values.dev.template.yaml
@@ -9,4 +9,3 @@ java:
     AZUREAD__REDIRECTURI: https://${SERVICE_FQDN}/home
     DOM1__POSTLOGOUTREDIRECTURI: https://${SERVICE_FQDN}/logout
     DOM1__REDIRECTURI: https://${SERVICE_FQDN}/home
-    VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-788.dev.platform.hmcts.net/


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10361


### Change description ###
- Call the new `ReassignJudiciaryJudge` API endpoint to update the judge instead of removing and adding the new judge participants
- Update the `EditHearing` validation to enable the hearing to be edited on V2 when there are no non-judiciary participants
- The `TelephoneParticipants` property has been removed from bookings api, so remove the mapping
