### PR TITLE
VIH-10394 No warning when creating a hearing without participants

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.html
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/add-participant/add-participant.component.html
@@ -6,7 +6,7 @@
 </div>
 
 <div
-  *ngIf="errorAlternativeEmail || errorJohAccountNotFound || errorJudiciaryAccount"
+  *ngIf="errorAlternativeEmail || errorJohAccountNotFound || errorJudiciaryAccount || displayErrorNoParticipants"
   class="govuk-error-summary govuk-!-width-full"
   aria-labelledby="error-summary-title"
   role="alert"
@@ -25,12 +25,15 @@
       <li *ngIf="errorJudiciaryAccount">
         <a (click)="goToDiv('search-email-component')">{{ constants.Error.JohEmailErrorMsg }}</a>
       </li>
+      <li *ngIf="displayErrorNoParticipants">
+        <a (click)="goToDiv('add-participant-component')">{{ constants.Error.NoParticipantsErrorMsg }}</a>
+      </li>
     </ul>
   </div>
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
+  <div class="govuk-grid-column-one-half" id="add-participant-component">
     <h2 class="govuk-heading-m">Add a participant</h2>
     <form [formGroup]="form" (ngSubmit)="saveParticipant()" autocomplete="off">
       <div

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/constants.ts
@@ -27,7 +27,7 @@ export const Constants = {
         FirstNameErrorMsg: 'Please enter a first name',
         LastNameErrorMsg: 'Please enter a last name',
         PhoneErrorMsg: 'Please enter a valid telephone number',
-        NoParticipantsErrorMsg: 'Please enter at least one participant',
+        NoParticipantsErrorMsg: 'Please add at least one participant',
         CompanyErrorMsg: 'Please enter an organisation name',
         ReferenceMsg: 'Please enter a reference',
         RepresenteeErrorMsg: 'Please enter a representee',


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10394


### Change description ###
Displays a warning to the user when they are unable to proceed with booking a hearing due to not adding any participants
The `NoParticipantsErrorMsg` const isn't used, so have re-purposed it for this message