### PR TITLE
VIH-10530 Fix - Error for enhanced edit of multi-day booking with no participants

### DIFF
--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -821,10 +821,22 @@ namespace AdminWebsite.Controllers
                 }
             }
             
+            request.ExistingJudiciaryParticipants = MapExistingJudiciaryParticipants(judiciaryParticipants, 
+                originalHearing, 
+                skipUnchangedParticipants: skipUnchangedParticipants);
+
+            return request;
+        }
+
+        private static List<EditableUpdateJudiciaryParticipantRequestV2> MapExistingJudiciaryParticipants(IEnumerable<JudiciaryParticipantRequest> judiciaryParticipantsToUpdate,
+            HearingDetailsResponse originalHearing, bool skipUnchangedParticipants = true)
+        {
             // get existing judiciary participants based on the personal code being present in the original hearing
-            var existingJohs = judiciaryParticipants.Where(jp =>
+            var existingJohs = judiciaryParticipantsToUpdate.Where(jp =>
                 originalHearing.JudiciaryParticipants.Exists(ojp => ojp.PersonalCode == jp.PersonalCode)).ToList();
 
+            var existingJudiciaryParticipants = new List<EditableUpdateJudiciaryParticipantRequestV2>();
+            
             foreach (var joh in existingJohs)
             {
                 if (skipUnchangedParticipants)
@@ -839,7 +851,7 @@ namespace AdminWebsite.Controllers
                 }
                 
                 var roleCode = Enum.Parse<JudiciaryParticipantHearingRoleCode>(joh.Role);
-                request.ExistingJudiciaryParticipants.Add(new EditableUpdateJudiciaryParticipantRequestV2
+                existingJudiciaryParticipants.Add(new EditableUpdateJudiciaryParticipantRequestV2
                 {
                     PersonalCode = joh.PersonalCode,
                     DisplayName = joh.DisplayName,
@@ -848,7 +860,7 @@ namespace AdminWebsite.Controllers
                 });
             }
 
-            return request;
+            return existingJudiciaryParticipants;
         }
 
         private static List<LinkedParticipantRequest> ExtractLinkedParticipants(

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -557,7 +557,7 @@ namespace AdminWebsite.Controllers
                         RemovedEndpointIds = endpointsV1.RemovedEndpointIds.ToList()
                     };
                     hearingRequest.Endpoints = endpointsV2;
-                    hearingRequest.JudiciaryParticipants = MapUpdateJudiciaryParticipantsRequestV2(judiciaryParticipants, hearingToUpdate);
+                    hearingRequest.JudiciaryParticipants = MapUpdateJudiciaryParticipantsRequestV2(judiciaryParticipants, hearingToUpdate, skipUnchangedParticipants: false);
                 
                     bookingsApiRequest.Hearings.Add(hearingRequest);
                 }
@@ -773,7 +773,7 @@ namespace AdminWebsite.Controllers
         }
 
         private static UpdateJudiciaryParticipantsRequestV2 MapUpdateJudiciaryParticipantsRequestV2(List<JudiciaryParticipantRequest> judiciaryParticipants,
-            HearingDetailsResponse originalHearing)
+            HearingDetailsResponse originalHearing, bool skipUnchangedParticipants = true)
         {
             var request = new UpdateJudiciaryParticipantsRequestV2();
             
@@ -827,12 +827,15 @@ namespace AdminWebsite.Controllers
 
             foreach (var joh in existingJohs)
             {
-                // Only update the joh if their details have changed
-                var originalJoh = originalHearing.JudiciaryParticipants.Find(x => x.PersonalCode == joh.PersonalCode);
-                if (joh.DisplayName == originalJoh.DisplayName &&
-                    joh.Role == originalJoh.RoleCode)
+                if (skipUnchangedParticipants)
                 {
-                    continue;
+                    // Only update the joh if their details have changed
+                    var originalJoh = originalHearing.JudiciaryParticipants.Find(x => x.PersonalCode == joh.PersonalCode);
+                    if (joh.DisplayName == originalJoh.DisplayName &&
+                        joh.Role == originalJoh.RoleCode)
+                    {
+                        continue;
+                    }
                 }
                 
                 var roleCode = Enum.Parse<JudiciaryParticipantHearingRoleCode>(joh.Role);

--- a/charts/vh-admin-web/values.dev.template.yaml
+++ b/charts/vh-admin-web/values.dev.template.yaml
@@ -9,4 +9,3 @@ java:
     AZUREAD__REDIRECTURI: https://${SERVICE_FQDN}/home
     DOM1__POSTLOGOUTREDIRECTURI: https://${SERVICE_FQDN}/logout
     DOM1__REDIRECTURI: https://${SERVICE_FQDN}/home
-    VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-832.dev.platform.hmcts.net/

--- a/charts/vh-admin-web/values.dev.template.yaml
+++ b/charts/vh-admin-web/values.dev.template.yaml
@@ -9,3 +9,4 @@ java:
     AZUREAD__REDIRECTURI: https://${SERVICE_FQDN}/home
     DOM1__POSTLOGOUTREDIRECTURI: https://${SERVICE_FQDN}/logout
     DOM1__REDIRECTURI: https://${SERVICE_FQDN}/home
+    VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-832.dev.platform.hmcts.net/


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10530


### Change description ###
The `MapUpdateJudiciaryParticipantsRequestV2` method skips judiciary participants that have not changed in order to avoid an additional call to bookings API when updating hearings. However we don't want to do this for the enhanced update of multi-day bookings, as this is already handled on the bookings API side and results in a bad request from not sending any participants.

Refactor the mapping of existing judiciary participants into a separate method