### PR TITLE
VIH-10618 Fix edit links not showing for multi day hearing

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/shared/booking-edit/booking-edit.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/shared/booking-edit/booking-edit.component.spec.ts
@@ -79,11 +79,4 @@ describe('BookingEditComponent', () => {
         videoHearingServiceSpy.isConferenceClosed.and.returnValue(true);
         expect(component.canEdit).toBe(false);
     });
-    it('should not be able to edit when booking is multi day and multi day booking enhancements are enabled', () => {
-        const currentRequest = new HearingModel();
-        currentRequest.isMultiDay = true;
-        videoHearingServiceSpy.getCurrentRequest.and.returnValue(currentRequest);
-        component.multiDayBookingEnhancementsEnabled = true;
-        expect(component.canEdit).toBe(false);
-    });
 });

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/shared/booking-edit/booking-edit.component.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/shared/booking-edit/booking-edit.component.ts
@@ -41,16 +41,7 @@ export class BookingEditComponent {
     }
 
     get canEdit() {
-        if (this.videoHearingsService.isConferenceClosed() || this.videoHearingsService.isHearingAboutToStart()) {
-            return false;
-        }
-
-        const booking = this.videoHearingsService.getCurrentRequest();
-        if (booking.isMultiDay && this.multiDayBookingEnhancementsEnabled) {
-            return false;
-        }
-
-        return true;
+        return !this.videoHearingsService.isConferenceClosed() && !this.videoHearingsService.isHearingAboutToStart();
     }
 
     edit() {


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10618


### Change description ###
A restriction was previously added to hide the edit hyperlinks on the summary page when editing a multi day booking with the multi day enhancements toggled on, this was because the editing of details had not yet been implemented for the multi-hearing edit.

Now that it has been implemented, this restriction is no longer needed.
