### PR TITLE
VIH-10642 bug fix adding an interpreter last minute

### DIFF
--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditMultiDayHearingTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/HearingsController/EditMultiDayHearingTests.cs
@@ -170,7 +170,7 @@ namespace AdminWebsite.UnitTests.Controllers.HearingsController
                         h.HearingRoomName == request.HearingRoomName &&
                         h.OtherInformation == request.OtherInformation &&
                         h.CaseNumber == request.CaseNumber &&
-                        h.AudioRecordingRequired == request.AudioRecordingRequired &&
+                        !h.AudioRecordingRequired && // must be false (original value) as we added an interpreter
                         h.Participants.ExistingParticipants.Count == 3 &&
                         h.Participants.NewParticipants.Count == 3 &&
                         h.Participants.NewParticipants.Exists(p => p.ContactEmail == newParticipant.ContactEmail) &&

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -454,9 +454,9 @@ namespace AdminWebsite.Controllers
             if (_featureToggles.UseV2Api())
             {
                 var updateHearingRequestV2 = HearingUpdateRequestMapper.MapToV2(request, _userIdentity.GetUserIdentityName());
+                await _bookingsApiClient.UpdateHearingDetails2Async(hearingId, updateHearingRequestV2);
                 await UpdateParticipantsV2(hearingId, request.Participants, request.Endpoints, originalHearing);
                 await UpdateJudiciaryParticipants(hearingId, request.JudiciaryParticipants, originalHearing);
-                await _bookingsApiClient.UpdateHearingDetails2Async(hearingId, updateHearingRequestV2);
             }
             else
             {

--- a/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
+++ b/AdminWebsite/AdminWebsite/Controllers/HearingsController.cs
@@ -442,7 +442,7 @@ namespace AdminWebsite.Controllers
             // an interpreter is added. Revert to the original audio recording setting to avoid the time clash.
             // This is only an issue because we update hearing details and participants in the same request.
             var containsInterpreter =
-                request.Participants.Exists(p => p.HearingRoleCode == HearingRoleCodes.Interpreter);
+                request.Participants.Exists(p => p.IsInterpreter());
             
             if(containsInterpreter)
             {

--- a/AdminWebsite/AdminWebsite/Mappers/EditMultiDayHearing/HearingRequestMapper.cs
+++ b/AdminWebsite/AdminWebsite/Mappers/EditMultiDayHearing/HearingRequestMapper.cs
@@ -1,4 +1,5 @@
 using AdminWebsite.Contracts.Requests;
+using AdminWebsite.Models;
 using AdminWebsite.Models.EditMultiDayHearing;
 using BookingsApi.Contract.V2.Requests;
 using BookingsApi.Contract.V2.Responses;
@@ -27,6 +28,16 @@ namespace AdminWebsite.Mappers.EditMultiDayHearing
                 AudioRecordingRequired = hearingChanges.AudioRecordingRequiredChanged ? 
                     editMultiDayHearingRequest.AudioRecordingRequired : hearing.AudioRecordingRequired
             };
+            
+            if (hearingChanges.ParticipantChanges.Exists(p =>
+                    p.ParticipantRequest.HearingRoleCode == HearingRoleCodes.Interpreter))
+            {
+                // Adding an interpreter forces the audio recording to be required. The update hearing details do not work
+                // with the close to start time window, but the domain will update the audio recording required flag when
+                // an interpreter is added. Revert to the original audio recording setting to avoid the time clash.
+                // This is only an issue because we update hearing details and participants in the same request.
+                hearingRequest.AudioRecordingRequired = hearing.AudioRecordingRequired;
+            }
 
             return hearingRequest;
         }

--- a/AdminWebsite/AdminWebsite/Models/EditParticipantRequest.cs
+++ b/AdminWebsite/AdminWebsite/Models/EditParticipantRequest.cs
@@ -112,8 +112,8 @@ namespace AdminWebsite.Models
 
         public bool IsInterpreter()
         {
-            return HearingRoleCode == HearingRoleCodes.Interpreter ||
-                   HearingRoleName.Equals("Interpreter", StringComparison.CurrentCultureIgnoreCase);
+            return HearingRoleCode?.Equals(HearingRoleCodes.Interpreter) == true ||
+                   HearingRoleName?.Equals("Interpreter", StringComparison.CurrentCultureIgnoreCase) == true;
         }
 
         public static IEqualityComparer<EditParticipantRequest> EditParticipantRequestComparer { get; } = new EditParticipantRequestEqualityComparer();

--- a/AdminWebsite/AdminWebsite/Models/EditParticipantRequest.cs
+++ b/AdminWebsite/AdminWebsite/Models/EditParticipantRequest.cs
@@ -110,6 +110,12 @@ namespace AdminWebsite.Models
             }
         }
 
+        public bool IsInterpreter()
+        {
+            return HearingRoleCode == HearingRoleCodes.Interpreter ||
+                   HearingRoleName.Equals("Interpreter", StringComparison.CurrentCultureIgnoreCase);
+        }
+
         public static IEqualityComparer<EditParticipantRequest> EditParticipantRequestComparer { get; } = new EditParticipantRequestEqualityComparer();
 
     }

--- a/AdminWebsite/AdminWebsite/Models/HearingRoleCodes.cs
+++ b/AdminWebsite/AdminWebsite/Models/HearingRoleCodes.cs
@@ -1,0 +1,12 @@
+namespace AdminWebsite.Models;
+
+public static class HearingRoleCodes
+{
+    public const string Applicant = "APPL";
+    public const string Intermediary = "INTE";
+    public const string Representative = "RPTT";
+    public const string Respondent = "RESP";
+    public const string StaffMember = "STAF";
+    public const string Interpreter = "INTP";
+    public const string WelfareRepresentative = "WERP";
+}

--- a/charts/vh-admin-web/values.dev.template.yaml
+++ b/charts/vh-admin-web/values.dev.template.yaml
@@ -9,3 +9,4 @@ java:
     AZUREAD__REDIRECTURI: https://${SERVICE_FQDN}/home
     DOM1__POSTLOGOUTREDIRECTURI: https://${SERVICE_FQDN}/logout
     DOM1__REDIRECTURI: https://${SERVICE_FQDN}/home
+    VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-848.dev.platform.hmcts.net/


### PR DESCRIPTION
### Jira link (if applicable)

VIH-10642

### Change description ###

Adding an interpreter forces the audio recording to be required. The update hearing details do not work with the close to start time window, but the domain will update the audio recording required flag when an interpreter is added. Revert to the original audio recording setting to avoid the time clash. This is only an issue because we update hearing details and participants in the same request.