### PR TITLE
VIH-10649 Map user roles from claims

### DIFF
--- a/AdminWebsite/AdminWebsite.UnitTests/Controllers/UserIdentityControllerTests.cs
+++ b/AdminWebsite/AdminWebsite.UnitTests/Controllers/UserIdentityControllerTests.cs
@@ -8,119 +8,54 @@ using BookingsApi.Client;
 using BookingsApi.Contract.V1.Responses;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 
 namespace AdminWebsite.UnitTests.Controllers
 {
     public class UserIdentityControllerTests
     {
         private Mock<IBookingsApiClient> _bookingsApiClientMock;
-        private Mock<ILogger<UserIdentityController>> _loggerMock;
 
         private ClaimsPrincipal _claimsPrincipal;
-        private JusticeUserResponse _justiceUserResponse;
         private List<JusticeUserResponse> _justiceUserListResponse;
         private UserIdentityController _controller;
 
         [SetUp]
         public void Setup()
         {
-            _justiceUserResponse = new JusticeUserResponse
-            {
-                IsVhTeamLeader = true
-            };
-
-            
-            _loggerMock = new Mock<ILogger<UserIdentityController>>();
             _bookingsApiClientMock = new Mock<IBookingsApiClient>();
-            _bookingsApiClientMock.Setup(x => x.GetJusticeUserByUsernameAsync(It.IsAny<string>())).ReturnsAsync(_justiceUserResponse);
         }
 
         [Test]
-        public async Task should_return_not_found_when_username_cannot_be_found_from_claims()
-        {
-            var claims = new List<Claim>
-            {
-                new("unique_user", "user@name.com"),
-                new(ClaimTypes.NameIdentifier, "userId"),
-                new("name", "John Doe")
-            };
-            
-            var identity = new ClaimsIdentity(claims, "TestAuthType", "preferred_username", ClaimTypes.Role);
-            var claimsPrincipal = new ClaimsPrincipal(identity);
-            _controller = SetupControllerWithClaims(claimsPrincipal);
-            
-            var response = await _controller.GetUserProfile();
-            var result = response.Result.As<ObjectResult>();
-
-            result.Should().NotBeNull();
-
-            ClassicAssert.AreEqual(404, result.StatusCode);
-        }
-        
-        [Test]
-        public async Task should_return_status_code_result_when_api_errors_with_non_404()
+        public void should_map_claims_to_user_profile()
         {
             _claimsPrincipal = new ClaimsPrincipalBuilder()
                 .WithRole(AppRoles.CaseAdminRole)
-                .Build();
-            _controller = SetupControllerWithClaims(_claimsPrincipal);
-
-            _bookingsApiClientMock.Setup(x => x.GetJusticeUserByUsernameAsync(It.IsAny<string>()))
-                .ThrowsAsync(new BookingsApiException("message", 400, "response", null, null));
-
-            var response = await _controller.GetUserProfile();
-            var result = response.Result.As<ObjectResult>();
-
-            result.Should().NotBeNull();
-
-            ClassicAssert.AreEqual(400, result.StatusCode);
-        }
-
-        [Test]
-        public async Task should_not_mark_user_as_vh_lead_when_not_found()
-        {
-            _claimsPrincipal = new ClaimsPrincipalBuilder()
-                .WithRole(AppRoles.CaseAdminRole)
+                .WithRole(AppRoles.AdministratorRole)
                 .Build();
             _controller = SetupControllerWithClaims(_claimsPrincipal);
 
             _bookingsApiClientMock.Setup(x => x.GetJusticeUserByUsernameAsync(It.IsAny<string>()))
                 .ThrowsAsync(new BookingsApiException("not found message", 404, "not found response", null, null));
 
-            var response = await _controller.GetUserProfile();
+            var response = _controller.GetUserProfile();
             var result = response.Result.As<ObjectResult>();
 
             result.Should().NotBeNull();
-            var userProfile = (UserProfileResponse)result.Value;
-
-            userProfile.IsVhTeamLeader.Should().BeFalse();
-        }
-
-        [Test]
-        public async Task should_retrieve_team_lead_status_from_bookings_api()
-        {
-            _claimsPrincipal = new ClaimsPrincipalBuilder()
-                .WithRole(AppRoles.CaseAdminRole)
-                .Build();
-            _controller = SetupControllerWithClaims(_claimsPrincipal);
-            var response = await _controller.GetUserProfile();
-            var result = response.Result.As<OkObjectResult>();
-
-            result.Should().NotBeNull();
-            var userProfile = (UserProfileResponse)result.Value;
+            var userProfile = (UserProfileResponse)result.Value!;
 
             userProfile.IsVhTeamLeader.Should().BeTrue();
+            userProfile.IsVhOfficerAdministratorRole.Should().BeTrue();
+            userProfile.IsCaseAdministrator.Should().BeTrue();
         }
 
         [Test]
-        public async Task should_get_profile_response_for_judge()
+        public void should_get_profile_response_for_judge()
         {
             _claimsPrincipal = new ClaimsPrincipalBuilder()
                 .WithRole(AppRoles.JudgeRole)
                 .Build();
             _controller = SetupControllerWithClaims(_claimsPrincipal);
-            var response = await _controller.GetUserProfile();
+            var response = _controller.GetUserProfile();
             var result = response.Result.As<OkObjectResult>();
 
             result.Should().NotBeNull();
@@ -131,13 +66,13 @@ namespace AdminWebsite.UnitTests.Controllers
         }
         
         [Test]
-        public async Task should_get_profile_response_for_vho()
+        public void should_get_profile_response_for_vho()
         {
             _claimsPrincipal = new ClaimsPrincipalBuilder()
                 .WithRole(AppRoles.VhOfficerRole)
                 .Build();
             _controller = SetupControllerWithClaims(_claimsPrincipal);
-            var response = await _controller.GetUserProfile();
+            var response = _controller.GetUserProfile();
             var result = response.Result.As<OkObjectResult>();
 
             result.Should().NotBeNull();
@@ -148,13 +83,13 @@ namespace AdminWebsite.UnitTests.Controllers
         }
         
         [Test]
-        public async Task should_get_profile_response_for_case_admin()
+        public void should_get_profile_response_for_case_admin()
         {
             _claimsPrincipal = new ClaimsPrincipalBuilder()
                 .WithRole(AppRoles.CaseAdminRole)
                 .Build();
             _controller = SetupControllerWithClaims(_claimsPrincipal);
-            var response = await _controller.GetUserProfile();
+            var response = _controller.GetUserProfile();
             var result = response.Result.As<OkObjectResult>();
 
             result.Should().NotBeNull();
@@ -212,7 +147,7 @@ namespace AdminWebsite.UnitTests.Controllers
                 }
             };
 
-            return new UserIdentityController(_bookingsApiClientMock.Object, _loggerMock.Object)
+            return new UserIdentityController(_bookingsApiClientMock.Object)
             {
                 ControllerContext = context
             };


### PR DESCRIPTION
### Jira link (if applicable)

VIH-10649

### Change description ###

Remove redundant Bookings API to get justice user info call in place of using existing claims which already checks for justice user and maps the roles into the ClaimsPrincipal

API call drops from 300ms to 5ms