### PR TITLE
VIH-10843 add sonar to master build

### DIFF
--- a/azure-pipelines.sds.master-release.yml
+++ b/azure-pipelines.sds.master-release.yml
@@ -49,20 +49,20 @@ stages:
         - template: templates/dotnet/build-test-analyse.yml@azTemplates
           parameters:
             dotnetVersion: ${{ variables.dotnetVersion }}
-              nugetConfigPath: nuget.config
-              appName: ${{ variables.appName }}
-              dockerComposeTestFile: docker-compose.tests.yml
-              publishNodeTests: true
-              nodeTestResultFolder: $(System.DefaultWorkingDirectory)/AdminWebsite/AdminWebsite/ClientApp
-              sonarExtraProperties: |
-                sonar.exclusions=**/node_modules/**, **/*.spec.ts, *.spec.ts, **/ClientApp/src/*, **/ClientApp/src/app/testing/**, **/ClientApp/coverage/**/*, **/Startup.cs, **/Program.cs, **/ConfigureServicesExtensions.cs, **/Swagger/*.cs, **/src/app/testing/data/*.ts, **/auth-config.module.ts
-                sonar.cs.opencover.reportsPaths=$(System.DefaultWorkingDirectory)/coverage.opencover.xml
-                sonar.javascript.lcov.reportPaths=**/ClientApp/coverage/lcov.info
-                sonar.typescript.exclusions=**/node_modules/**, **/typings.d.ts, **/main.ts, **/environments/environment*.ts, **/*routing.module.ts, **/api-client.ts
-                sonar.coverage.exclusions=**/AdminWebsite/Configuration/**, **/AdminWebsite/Security/**, **/AdminWebsite.Testing.Common/**, **/AdminWebsite/Views/*, **/AdminWebsite/Pages/*, **/AdminWebsite.AcceptanceTests/*, **/AdminWebsite.*Tests/*
-                sonar.issue.ignore.multicriteria=e1
-                sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S6544
-                sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.ts
+            nugetConfigPath: nuget.config
+            appName: ${{ variables.appName }}
+            dockerComposeTestFile: docker-compose.tests.yml
+            publishNodeTests: true
+            nodeTestResultFolder: $(System.DefaultWorkingDirectory)/AdminWebsite/AdminWebsite/ClientApp
+            sonarExtraProperties: |
+              sonar.exclusions=**/node_modules/**, **/*.spec.ts, *.spec.ts, **/ClientApp/src/*, **/ClientApp/src/app/testing/**, **/ClientApp/coverage/**/*, **/Startup.cs, **/Program.cs, **/ConfigureServicesExtensions.cs, **/Swagger/*.cs, **/src/app/testing/data/*.ts, **/auth-config.module.ts
+              sonar.cs.opencover.reportsPaths=$(System.DefaultWorkingDirectory)/coverage.opencover.xml
+              sonar.javascript.lcov.reportPaths=**/ClientApp/coverage/lcov.info
+              sonar.typescript.exclusions=**/node_modules/**, **/typings.d.ts, **/main.ts, **/environments/environment*.ts, **/*routing.module.ts, **/api-client.ts
+              sonar.coverage.exclusions=**/AdminWebsite/Configuration/**, **/AdminWebsite/Security/**, **/AdminWebsite.Testing.Common/**, **/AdminWebsite/Views/*, **/AdminWebsite/Pages/*, **/AdminWebsite.AcceptanceTests/*, **/AdminWebsite.*Tests/*
+              sonar.issue.ignore.multicriteria=e1
+              sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S6544
+              sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.ts
 
 #####################################################
 # Manual Approval ###################################

--- a/azure-pipelines.sds.master-release.yml
+++ b/azure-pipelines.sds.master-release.yml
@@ -34,6 +34,37 @@ pool:
 
 stages:
 #####################################################
+# CI Build Tasks. ###################################
+- stage: CI_Build
+  dependsOn: []
+  variables:
+    - template: variables/shared.yaml
+  displayName: Test & Sonar
+  jobs:
+    - job: UnitAndIntegrationTests
+      displayName: 'Unit and Integration Tests'
+      steps:
+        - checkout: self
+
+        - template: templates/dotnet/build-test-analyse.yml@azTemplates
+          parameters:
+            dotnetVersion: ${{ variables.dotnetVersion }}
+              nugetConfigPath: nuget.config
+              appName: ${{ variables.appName }}
+              dockerComposeTestFile: docker-compose.tests.yml
+              publishNodeTests: true
+              nodeTestResultFolder: $(System.DefaultWorkingDirectory)/AdminWebsite/AdminWebsite/ClientApp
+              sonarExtraProperties: |
+                sonar.exclusions=**/node_modules/**, **/*.spec.ts, *.spec.ts, **/ClientApp/src/*, **/ClientApp/src/app/testing/**, **/ClientApp/coverage/**/*, **/Startup.cs, **/Program.cs, **/ConfigureServicesExtensions.cs, **/Swagger/*.cs, **/src/app/testing/data/*.ts, **/auth-config.module.ts
+                sonar.cs.opencover.reportsPaths=$(System.DefaultWorkingDirectory)/coverage.opencover.xml
+                sonar.javascript.lcov.reportPaths=**/ClientApp/coverage/lcov.info
+                sonar.typescript.exclusions=**/node_modules/**, **/typings.d.ts, **/main.ts, **/environments/environment*.ts, **/*routing.module.ts, **/api-client.ts
+                sonar.coverage.exclusions=**/AdminWebsite/Configuration/**, **/AdminWebsite/Security/**, **/AdminWebsite.Testing.Common/**, **/AdminWebsite/Views/*, **/AdminWebsite/Pages/*, **/AdminWebsite.AcceptanceTests/*, **/AdminWebsite.*Tests/*
+                sonar.issue.ignore.multicriteria=e1
+                sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S6544
+                sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.ts
+
+#####################################################
 # Manual Approval ###################################
 - ${{ each stage in parameters.stages }}:
   - stage: Manual_Approval_${{ stage.env }}


### PR DESCRIPTION
### Jira link

VIH-10843

### Change description

This pull request introduces a new CI build stage to the `azure-pipelines.sds.master-release.yml` file. The changes include setting up variables, defining the build and test jobs, and configuring SonarQube properties.

### CI Build Stage Addition:

* Added a new `CI_Build` stage with no dependencies and a display name "Test & Sonar". (`azure-pipelines.sds.master-release.yml`)