### PR TITLE
VIH-11136 remove unused vars and imports add unused imports to lint

### DIFF
--- a/AdminWebsite/AdminWebsite/ClientApp/.eslintrc.js
+++ b/AdminWebsite/AdminWebsite/ClientApp/.eslintrc.js
@@ -9,9 +9,17 @@ module.exports = {
         project: 'tsconfig.json',
         sourceType: 'module'
     },
-    plugins: ['eslint-plugin-import', '@angular-eslint/eslint-plugin', '@typescript-eslint', '@typescript-eslint/tslint', 'jasmine'],
+    plugins: [
+        'eslint-plugin-import',
+        '@angular-eslint/eslint-plugin',
+        '@typescript-eslint',
+        '@typescript-eslint/tslint',
+        'jasmine',
+        'unused-imports'
+    ],
     root: true,
     rules: {
+        'unused-imports/no-unused-imports': 'error',
         'jasmine/no-focused-tests': 'error',
         '@angular-eslint/component-class-suffix': 'error',
         '@angular-eslint/directive-class-suffix': 'error',

--- a/AdminWebsite/AdminWebsite/ClientApp/package-lock.json
+++ b/AdminWebsite/AdminWebsite/ClientApp/package-lock.json
@@ -63,6 +63,7 @@
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jasmine": "^4.1.3",
+        "eslint-plugin-unused-imports": "^4.1.4",
         "jasmine-core": "^5.1.2",
         "jasmine-spec-reporter": "~6.0.0",
         "karma": "^6.4.2",
@@ -8988,6 +8989,21 @@
       "engines": {
         "node": ">=8",
         "npm": ">=6"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
+      "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/AdminWebsite/AdminWebsite/ClientApp/package.json
+++ b/AdminWebsite/AdminWebsite/ClientApp/package.json
@@ -76,6 +76,7 @@
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jasmine": "^4.1.3",
+    "eslint-plugin-unused-imports": "^4.1.4",
     "jasmine-core": "^5.1.2",
     "jasmine-spec-reporter": "~6.0.0",
     "karma": "^6.4.2",

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/assign-judge/assign-judge.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/assign-judge/assign-judge.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/hearing-schedule/hearing-schedule.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/hearing-schedule/hearing-schedule.component.spec.ts
@@ -1,6 +1,6 @@
 import { DatePipe } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
-import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { AbstractControl, FormArray, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/other-information/other-information.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/other-information/other-information.component.spec.ts
@@ -11,10 +11,9 @@ import { ConfirmationPopupStubComponent } from '../../testing/stubs/confirmation
 import { BreadcrumbComponent } from '../breadcrumb/breadcrumb.component';
 import { OtherInformationComponent } from './other-information.component';
 import { ParticipantModel } from '../../common/model/participant.model';
-import { of } from 'rxjs';
 import { CaseModel } from 'src/app/common/model/case.model';
 import { HearingModel } from 'src/app/common/model/hearing.model';
-import { LaunchDarklyService, FeatureFlags } from 'src/app/services/launch-darkly.service';
+import { LaunchDarklyService } from 'src/app/services/launch-darkly.service';
 import { BreadcrumbStubComponent } from 'src/app/testing/stubs/breadcrumb-stub';
 
 function initHearingRequest(): HearingModel {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/item/participant-item.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/participant/item/participant-item.component.spec.ts
@@ -9,7 +9,6 @@ import { VideoHearingsService } from 'src/app/services/video-hearings.service';
 import { Constants } from 'src/app/common/constants';
 import { ParticipantModel } from 'src/app/common/model/participant.model';
 import { PageUrls } from 'src/app/shared/page-url.constants';
-import { of } from 'rxjs';
 import { VideoSupplier } from 'src/app/services/clients/api-client';
 
 const router = {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/booking/search-email/search-email.component.spec.ts
@@ -9,7 +9,7 @@ import { Logger } from '../../services/logger';
 import { SearchService } from '../../services/search.service';
 import { SearchEmailComponent } from './search-email.component';
 import { DebugElement, ElementRef } from '@angular/core';
-import { FeatureFlags, LaunchDarklyService } from 'src/app/services/launch-darkly.service';
+import { LaunchDarklyService } from 'src/app/services/launch-darkly.service';
 
 describe('SearchEmailComponent', () => {
     let component: SearchEmailComponent;

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/bookings-list/bookings-list/bookings-list.component.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientModule } from '@angular/common/http';
 import { Component, Directive, EventEmitter, Output } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
 import { AbstractControl, FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
@@ -9,7 +9,7 @@ import * as moment from 'moment';
 import { MomentModule } from 'ngx-moment';
 import { of } from 'rxjs';
 import { ConfigService } from 'src/app/services/config.service';
-import { FeatureFlags, LaunchDarklyService } from 'src/app/services/launch-darkly.service';
+import { LaunchDarklyService } from 'src/app/services/launch-darkly.service';
 import { Logger } from 'src/app/services/logger';
 import { ReferenceDataService } from 'src/app/services/reference-data.service';
 import { ReturnUrlService } from 'src/app/services/return-url.service';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/guards/change.guard.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/guards/change.guard.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRouteSnapshot, Router } from '@angular/router';
-import { CanDeactiveComponent, ChangesGuard } from './changes.guard';
-import { VhoWorkHoursNonAvailabilityTableComponent } from '../../work-allocation/edit-work-hours/vho-work-hours-non-availability-table/vho-work-hours-non-availability-table.component';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { ChangesGuard } from './changes.guard';
 
 const activatedRouteSnapshot: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-model.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/common/model/participant-model.spec.ts
@@ -1,4 +1,3 @@
-import { TestBed } from '@angular/core/testing';
 import { JudgeAccountType, JudgeResponse, PersonResponse } from 'src/app/services/clients/api-client';
 import { ParticipantModel } from './participant.model';
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/delete-participant/confirm-delete-popup/confirm-delete-popup.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/delete-participant/confirm-delete-popup/confirm-delete-popup.component.spec.ts
@@ -1,4 +1,3 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Logger } from 'src/app/services/logger';
 
 import { ConfirmDeletePopupComponent } from './confirm-delete-popup.component';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/delete-participant/delete-participant-search/delete-participant-search.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/delete-participant/delete-participant-search/delete-participant-search.component.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, flushMicrotasks, tick, waitForAsync } from '@angular/core/testing';
+import { fakeAsync, flushMicrotasks } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
 import { of } from 'rxjs';
 import { HearingsByUsernameForDeletionResponse } from 'src/app/services/clients/api-client';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/get-audio-file/get-audio-file-cvp/get-audio-file-cvp.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/get-audio-file/get-audio-file-cvp/get-audio-file-cvp.component.spec.ts
@@ -1,6 +1,5 @@
 import { fakeAsync, flush } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
-import { CvpAudioSearchModel } from 'src/app/common/model/cvp-audio-search-model';
 import { AudioLinkService, ICvpAudioRecordingResult } from 'src/app/services/audio-link-service';
 import { CvpForAudioFileResponse } from 'src/app/services/clients/api-client';
 import { Logger } from 'src/app/services/logger';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/get-audio-file/get-audio-file.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/get-audio-file/get-audio-file.component.spec.ts
@@ -1,5 +1,4 @@
 import { FormBuilder } from '@angular/forms';
-import { AudioLinkService } from '../services/audio-link-service';
 import { Logger } from '../services/logger';
 import { GetAudioFileComponent } from './get-audio-file.component';
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/security/logout.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/security/logout.component.spec.ts
@@ -1,10 +1,8 @@
 import { fakeAsync } from '@angular/core/testing';
-import { OidcSecurityService } from 'angular-auth-oidc-client';
-import { Observable, of, Subject } from 'rxjs';
 import { UserIdentityService } from '../services/user-identity.service';
 import { LogoutComponent } from './logout.component';
-import { MockAuthenticatedResult, MockSecurityService } from '../testing/mocks/MockOidcSecurityService';
-import { IdpProviders, SecurityService } from './services/security.service';
+import { MockSecurityService } from '../testing/mocks/MockOidcSecurityService';
+import { IdpProviders } from './services/security.service';
 
 describe('LogoutComponent', () => {
     let component: LogoutComponent;

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/security/reform-login.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/security/reform-login.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReformLoginComponent } from './reform-login.component';
 import { IdpProviders, SecurityService } from './services/security.service';
 import { Router } from '@angular/router';
-import { ConfigService } from '../services/config.service';
 
 describe('LoginReformComponent', () => {
     let component: ReformLoginComponent;

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/security/services/security.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/security/services/security.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { SecurityService, IdpProviders } from './security.service';
-import { OidcSecurityService, OpenIdConfiguration, LoginResponse } from 'angular-auth-oidc-client';
+import { OidcSecurityService, OpenIdConfiguration } from 'angular-auth-oidc-client';
 import { of } from 'rxjs';
 
 describe('SecurityService', () => {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/audio-link-service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/audio-link-service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, flush, flushMicrotasks, tick } from '@angular/core/testing';
+import { fakeAsync, flush } from '@angular/core/testing';
 import { Observable, of, throwError } from 'rxjs';
 import { MockLogger } from '../shared/testing/mock-logger';
 import { AudioLinkService, InvalidParametersError } from './audio-link-service';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/services/booking-details.service.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/services/booking-details.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { LinkedParticipantModel } from '../common/model/linked-participant.model';
 import { BookingDetailsService } from './booking-details.service';
 import {
     HearingDetailsResponse,

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/shared/booking-edit/booking-edit.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/shared/booking-edit/booking-edit.component.spec.ts
@@ -1,7 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { BookingsHearingResponse } from 'src/app/services/clients/api-client';
 import { VideoHearingsService } from 'src/app/services/video-hearings.service';
 import { BookingService } from '../../services/booking.service';
 import { BookingEditComponent } from './booking-edit.component';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/testing/data/workhours-allocation-test-data.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/testing/data/workhours-allocation-test-data.ts
@@ -1,5 +1,4 @@
 import { VhoWorkHoursResponse } from '../../services/clients/api-client';
-import { VhoWorkHoursTableComponent } from '../../work-allocation/edit-work-hours/vho-work-hours-table/vho-work-hours-table.component';
 export class MockWorkAllocationValuesWorkHours {
     static VhoWorkHoursResponse(): VhoWorkHoursResponse[] {
         const jsonObj: [] = JSON.parse(

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/testing/mocks/MockChangesGuard.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/testing/mocks/MockChangesGuard.ts
@@ -1,4 +1,3 @@
-import { CanDeactiveComponent } from 'src/app/common/guards/changes.guard';
 export class MockChangesGuard {
     private _flag: boolean;
     canDeactivate() {

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/testing/mocks/MockLaunchDarklyService.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/testing/mocks/MockLaunchDarklyService.ts
@@ -1,4 +1,4 @@
-import { OpenIdConfiguration, LoginResponse, AuthenticatedResult, ConfigAuthenticatedResult } from 'angular-auth-oidc-client';
+import { LoginResponse } from 'angular-auth-oidc-client';
 import { LDFlagValue } from 'launchdarkly-js-client-sdk';
 import { Observable, of } from 'rxjs';
 

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/testing/stubs/sign-out-popup-stub.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/testing/stubs/sign-out-popup-stub.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Output, EventEmitter } from '@angular/core';
 
 @Component({
     selector: 'app-sign-out-popup',

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/upload-work-hours/upload-work-hours.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/upload-work-hours/upload-work-hours.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
 import { of } from 'rxjs';
 import { FileType } from 'src/app/common/model/file-type';

--- a/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/work-allocation.component.spec.ts
+++ b/AdminWebsite/AdminWebsite/ClientApp/src/app/work-allocation/work-allocation.component.spec.ts
@@ -1,7 +1,7 @@
-import { Component, DebugElement, EventEmitter, Input, NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Component, DebugElement, EventEmitter, Input } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { Subject, of, takeUntil } from 'rxjs';
+import { of } from 'rxjs';
 import { UserIdentityService } from '../services/user-identity.service';
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
 import { WorkAllocationComponent } from './work-allocation.component';


### PR DESCRIPTION
### Jira link

VIH-11136

### Change description

Adding a new ESLint plugin for unused imports and cleaning up unused imports across multiple files.

### ESLint Plugin Addition:
* Added `eslint-plugin-unused-imports` to the list of plugins in `.eslintrc.js` and configured a rule to flag unused imports as errors.